### PR TITLE
chore 🧹 (kgateway): remove namespace.yaml from kustomization resources

### DIFF
--- a/infrastructure/kgateway/kustomization.yaml
+++ b/infrastructure/kgateway/kustomization.yaml
@@ -1,6 +1,5 @@
 namespace: kgateway-system
 resources:
-  - namespace.yaml
   - helmrepo.yaml
   - helmrelease-crds.yaml
   - helmrelease.yaml


### PR DESCRIPTION
Signed-off-by: Victor Hang <vhvictorhang@gmail.com>
