### PR TITLE
refactor 🎨 (crossplane-resources): rename mgmt network to default in Crossplane resources

### DIFF
--- a/infrastructure/crossplane-resources/openstack/kustomization.yaml
+++ b/infrastructure/crossplane-resources/openstack/kustomization.yaml
@@ -1,6 +1,6 @@
 namespace: yaook
 resources:
-  - network-mgmt.yaml
+  - network-default.yaml
   - network-lbext.yaml
   - providerConfig.yaml
   - externalnetwork.yaml

--- a/infrastructure/crossplane-resources/openstack/network-default.yaml
+++ b/infrastructure/crossplane-resources/openstack/network-default.yaml
@@ -1,35 +1,35 @@
 apiVersion: networking.openstack.m.crossplane.io/v1alpha1
 kind: NetworkV2
 metadata:
-  name: mgmt
+  name: default
 spec:
   forProvider:
     adminStateUp: true
     shared: false
-    name: mgmt
+    name: default
 ---
 apiVersion: networking.openstack.m.crossplane.io/v1alpha1
 kind: SubnetV2
 metadata:
-  name: mgmt
+  name: default
 spec:
   forProvider:
-    name: mgmt
+    name: default
     cidr: 192.168.0.0/24
     dnsNameservers:
       - 1.1.1.1
       - 1.0.0.1
     networkIdRef:
-      name: mgmt
+      name: default
     enableDhcp: true
 ---
 apiVersion: networking.openstack.m.crossplane.io/v1alpha1
 kind: RouterInterfaceV2
 metadata:
-  name: mgmtext
+  name: defaultext
 spec:
   forProvider:
     routerIdRef:
       name: ext
     subnetIdRef:
-      name: mgmt
+      name: default

--- a/infrastructure/kgateway/crds/helmrelease-crds.yaml
+++ b/infrastructure/kgateway/crds/helmrelease-crds.yaml
@@ -8,7 +8,7 @@ spec:
   chart:
     spec:
       chart: kgateway-crds
-      version: v2.2.2
+      version: v2.3.0
       interval: 5m
       sourceRef:
         kind: HelmRepository

--- a/infrastructure/kgateway/helmrelease.yaml
+++ b/infrastructure/kgateway/helmrelease.yaml
@@ -10,7 +10,7 @@ spec:
   chart:
     spec:
       chart: kgateway
-      version: v2.2.2
+      version: v2.3.0
       interval: 5m
       sourceRef:
         kind: HelmRepository

--- a/infrastructure/yaook/gateway/kustomization.yaml
+++ b/infrastructure/yaook/gateway/kustomization.yaml
@@ -8,3 +8,4 @@ resources:
   - tlsroute-vnc.yaml
   - tlsroute-cinder.yaml
   - tlsroute-horizon.yaml
+  - tlsroute-octavia.yaml

--- a/infrastructure/yaook/gateway/listenerset.yaml
+++ b/infrastructure/yaook/gateway/listenerset.yaml
@@ -58,3 +58,9 @@ spec:
       hostname: "keystone.rpcu.vpn"
       tls:
         mode: Passthrough
+    - protocol: TLS
+      port: 443
+      name: yaook-passthrough-octavia
+      hostname: "octavia.rpcu.vpn"
+      tls:
+        mode: Passthrough

--- a/infrastructure/yaook/gateway/tlsroute-octavia.yaml
+++ b/infrastructure/yaook/gateway/tlsroute-octavia.yaml
@@ -1,0 +1,18 @@
+apiVersion: gateway.networking.k8s.io/v1alpha3
+kind: TLSRoute
+metadata:
+  name: tlsroute-octavia
+  namespace: yaook
+spec:
+  parentRefs:
+    - group: gateway.networking.x-k8s.io
+      kind: XListenerSet
+      name: yaook-passthrough-listeners
+      namespace: yaook
+      sectionName: yaook-passthrough-octavia # Target the new TLS passthrough listener
+  hostnames:
+    - "octavia.rpcu.vpn"
+  rules:
+    - backendRefs:
+        - name: octavia
+          port: 9877


### PR DESCRIPTION
Signed-off-by: Victor Hang <vhvictorhang@gmail.com>
