### PR TITLE
chore 🧹 (yaook): Increase message queue replicas from 1 to 3 for cinder, neutron, nova, and octavia operators

### DIFF
--- a/infrastructure/yaook/cinder.yaml
+++ b/infrastructure/yaook/cinder.yaml
@@ -13,7 +13,7 @@ spec:
     backup:
       schedule: "0 * * * *"
   messageQueue:
-    replicas: 1
+    replicas: 3
     resources:
       rabbitmq:
         limits:

--- a/infrastructure/yaook/neutron.yaml
+++ b/infrastructure/yaook/neutron.yaml
@@ -20,7 +20,7 @@ spec:
   keystoneRef:
     name: keystone
   messageQueue:
-    replicas: 1
+    replicas: 3
     resources:
       rabbitmq:
         limits:

--- a/infrastructure/yaook/nova.yaml
+++ b/infrastructure/yaook/nova.yaml
@@ -49,7 +49,7 @@ spec:
     volumeLockDurationSeconds: 30
   messageQueue:
     cell1:
-      replicas: 1
+      replicas: 3
       resources:
         rabbitmq:
           limits:

--- a/infrastructure/yaook/octavia.yaml
+++ b/infrastructure/yaook/octavia.yaml
@@ -31,7 +31,7 @@ spec:
       schedule: "0 * * * *"
   memcached: {}
   messageQueue:
-    replicas: 1
+    replicas: 3
   issuerRef:
     name: yaook-internal
   targetRelease: "2025.1"


### PR DESCRIPTION
Signed-off-by: Victor Hang <vhvictorhang@gmail.com>
