### PR TITLE
fix 🐛 (yaook/octavia): configure Octavia worker and health manager to schedule when rules are unsatisfiable

### DIFF
--- a/infrastructure/yaook/octavia.yaml
+++ b/infrastructure/yaook/octavia.yaml
@@ -13,8 +13,10 @@ spec:
       createIngress: false
       fqdn: "octavia.rpcu.vpn"
       port: 443
-  health_manager: {}
-  worker: {}
+  worker:
+    scheduleRuleWhenUnsatisfiable: ScheduleAnyway
+  health_manager:
+    scheduleRuleWhenUnsatisfiable: ScheduleAnyway
   housekeeping:
     replicas: 3
   networking:


### PR DESCRIPTION
Signed-off-by: Victor Hang <vhvictorhang@gmail.com>
