### PR TITLE
dfgdf

### DIFF
--- a/infrastructure/crossplane-resources/openstack/groups.yaml
+++ b/infrastructure/crossplane-resources/openstack/groups.yaml
@@ -12,7 +12,7 @@ kind: RoleV3
 metadata:
   name: admin
   annotations:
-    crossplane.io/external-name: "222436f91fc640ba9e64c67b5779573f"
+    crossplane.io/external-name: "af51259b8601414880f6af3bfd5a8022"
 spec:
   forProvider:
     name: admin
@@ -25,6 +25,6 @@ spec:
   forProvider:
     roleIdRef:
       name: admin
-    groupId: "1b2083fcdcf5419397ba2e4091da0b62"
+    groupId: "06aa1b3667ac4d5196632127eef6969f"
     projectIdRef:
       name: admin

--- a/infrastructure/crossplane-resources/openstack/projects.yaml
+++ b/infrastructure/crossplane-resources/openstack/projects.yaml
@@ -2,7 +2,7 @@ apiVersion: identity.openstack.m.crossplane.io/v1alpha1
 kind: ProjectV3
 metadata:
   annotations:
-    crossplane.io/external-name: "3c1e9678f76b440da67e6a3bca8313a0"
+    crossplane.io/external-name: "3925036867fb4274bf59754dfae9027c"
   name: admin
 spec:
   forProvider:

--- a/infrastructure/crossplane-resources/openstack/securityGroups.yaml
+++ b/infrastructure/crossplane-resources/openstack/securityGroups.yaml
@@ -2,7 +2,7 @@ apiVersion: networking.openstack.m.crossplane.io/v1alpha1
 kind: SecgroupV2
 metadata:
   annotations:
-    crossplane.io/external-name: "a42ce918-46d5-40ee-9e29-1a813f6c31d3"
+    crossplane.io/external-name: "ab2a0317-c65a-40e2-917a-61ed48233102"
   name: default
 spec:
   forProvider:

--- a/infrastructure/yaook/cinder.yaml
+++ b/infrastructure/yaook/cinder.yaml
@@ -11,7 +11,7 @@ spec:
       ingressClassName: nginx
       port: 443
     publishEndpoint: true
-    replicas: 3
+    replicas: 1
     scheduleRuleWhenUnsatisfiable: ScheduleAnyway
   backends:
     rook-ceph-rbd:
@@ -40,9 +40,9 @@ spec:
       schedule: 0 * * * *
       warmKeepMax: "3"
     proxy:
-      replicas: 3
+      replicas: 1
       scheduleRuleWhenUnsatisfiable: ScheduleAnyway
-    replicas: 3
+    replicas: 1
     scheduleRuleWhenUnsatisfiable: ScheduleAnyway
     storageSize: 8Gi
     timeoutClient: 300
@@ -58,10 +58,10 @@ spec:
   memcached:
     connections: 1024
     memory: 512
-    replicas: 3
+    replicas: 1
     scheduleRuleWhenUnsatisfiable: ScheduleAnyway
   messageQueue:
-    replicas: 3
+    replicas: 1
     resources:
       rabbitmq:
         limits:
@@ -75,6 +75,6 @@ spec:
   region:
     name: hetzner
   scheduler:
-    replicas: 3
+    replicas: 1
     scheduleRuleWhenUnsatisfiable: ScheduleAnyway
   targetRelease: "2025.1"

--- a/infrastructure/yaook/designate.yaml
+++ b/infrastructure/yaook/designate.yaml
@@ -16,7 +16,7 @@ spec:
       ingressClassName: nginx
       port: 443
     publishEndpoint: true
-    replicas: 3
+    replicas: 1
     scheduleRuleWhenUnsatisfiable: ScheduleAnyway
   database:
     backup:
@@ -24,9 +24,9 @@ spec:
       schedule: 0 * * * *
       warmKeepMax: "3"
     proxy:
-      replicas: 3
+      replicas: 1
       scheduleRuleWhenUnsatisfiable: ScheduleAnyway
-    replicas: 3
+    replicas: 1
     scheduleRuleWhenUnsatisfiable: ScheduleAnyway
     storageSize: 8Gi
     timeoutClient: 300
@@ -44,10 +44,10 @@ spec:
   memcached:
     connections: 1024
     memory: 512
-    replicas: 3
+    replicas: 1
     scheduleRuleWhenUnsatisfiable: ScheduleAnyway
   messageQueue:
-    replicas: 3
+    replicas: 1
     resources:
       rabbitmq:
         limits:
@@ -68,14 +68,14 @@ spec:
         schedule: 0 * * * *
         warmKeepMax: "3"
       proxy:
-        replicas: 3
+        replicas: 1
         scheduleRuleWhenUnsatisfiable: ScheduleAnyway
-      replicas: 3
+      replicas: 1
       scheduleRuleWhenUnsatisfiable: ScheduleAnyway
       storageSize: 8Gi
       timeoutClient: 300
       tolerateNodeDown: false
-    replicas: 3
+    replicas: 1
     scheduleRuleWhenUnsatisfiable: ScheduleAnyway
     subnetCidr: 10.244.0.0/16
   region:

--- a/infrastructure/yaook/glance.yaml
+++ b/infrastructure/yaook/glance.yaml
@@ -6,19 +6,19 @@ spec:
   keystoneRef:
     name: keystone
   database:
-    replicas: 3
+    replicas: 1
     timeoutClient: 300
     proxy:
-      replicas: 3
+      replicas: 1
     backup:
       schedule: "0 * * * *"
   memcached:
     connections: 1024
     memory: 512
-    replicas: 3
+    replicas: 1
     scheduleRuleWhenUnsatisfiable: ScheduleAnyway
   api:
-    replicas: 3
+    replicas: 1
     ingress:
       createIngress: false
       fqdn: "glance.rpcu.vpn"

--- a/infrastructure/yaook/horizon.yaml
+++ b/infrastructure/yaook/horizon.yaml
@@ -9,7 +9,7 @@ spec:
           name: horizon-websso
   keystoneRef:
     name: keystone
-  replicas: 3
+  replicas: 1
   ingress:
     createIngress: false
     fqdn: "os.rpcu.vpn"

--- a/infrastructure/yaook/horizon.yaml
+++ b/infrastructure/yaook/horizon.yaml
@@ -9,7 +9,7 @@ spec:
           name: horizon-websso
   keystoneRef:
     name: keystone
-  replicas: 1
+  replicas: 3
   ingress:
     createIngress: false
     fqdn: "os.rpcu.vpn"

--- a/infrastructure/yaook/keystone.yaml
+++ b/infrastructure/yaook/keystone.yaml
@@ -9,7 +9,7 @@ spec:
       fqdn: keystone.rpcu.vpn
       ingressClassName: nginx
       port: 443
-    replicas: 3
+    replicas: 1
     scheduleRuleWhenUnsatisfiable: ScheduleAnyway
     wsgiProcesses: 10
   database:
@@ -18,9 +18,9 @@ spec:
       schedule: 0 * * * *
       warmKeepMax: "3"
     proxy:
-      replicas: 3
+      replicas: 1
       scheduleRuleWhenUnsatisfiable: ScheduleAnyway
-    replicas: 3
+    replicas: 1
     scheduleRuleWhenUnsatisfiable: ScheduleAnyway
     storageSize: 8Gi
     timeoutClient: 300
@@ -56,7 +56,7 @@ spec:
   memcached:
     connections: 2000
     memory: 1024
-    replicas: 3
+    replicas: 1
     scheduleRuleWhenUnsatisfiable: ScheduleAnyway
   policy:
     admin_required: role:admin or is_admin:1

--- a/infrastructure/yaook/neutron.yaml
+++ b/infrastructure/yaook/neutron.yaml
@@ -8,20 +8,20 @@ spec:
       createIngress: false
       fqdn: "neutron.rpcu.vpn"
       port: 443
-    replicas: 3
+    replicas: 1
   database:
     proxy:
-      replicas: 3
+      replicas: 1
     backup:
       schedule: "0 * * * *"
-    replicas: 3
+    replicas: 1
     timeoutClient: 300
   issuerRef:
     name: yaook-internal
   keystoneRef:
     name: keystone
   messageQueue:
-    replicas: 3
+    replicas: 1
     resources:
       rabbitmq:
         limits:
@@ -30,7 +30,7 @@ spec:
   memcached:
     connections: 1024
     memory: 512
-    replicas: 3
+    replicas: 1
     scheduleRuleWhenUnsatisfiable: ScheduleAnyway
   neutronConfig:
     DEFAULT:
@@ -57,7 +57,7 @@ spec:
   setup:
     ovn:
       northboundOVSDB:
-        replicas: 3
+        replicas: 1
         backup:
           schedule: 0 12 * * *
       northd:
@@ -71,8 +71,8 @@ spec:
           # in large scale deployments, tune probe intervals separately for the ovsdb relays
           inactivityProbeMs: 120000
           remoteInactivityProbeMs: 60000
-          replicas: 5
-        replicas: 3
+          replicas: 1
+        replicas: 1
         backup:
           schedule: 0 12 * * *
       controller:

--- a/infrastructure/yaook/nova.yaml
+++ b/infrastructure/yaook/nova.yaml
@@ -10,7 +10,7 @@ spec:
       ingressClassName: nginx
       port: 443
     publishEndpoint: true
-    replicas: 3
+    replicas: 1
     scheduleRuleWhenUnsatisfiable: ScheduleAnyway
   compute:
     configTemplates:
@@ -31,7 +31,7 @@ spec:
             user: cinder
             uuid: b3ab713d-912b-49ed-adaf-bd74368e567a
   conductor:
-    replicas: 3
+    replicas: 1
     scheduleRuleWhenUnsatisfiable: ScheduleAnyway
   database:
     api:
@@ -44,9 +44,9 @@ spec:
           max_connections: 1337
           max_heap_table_size: 64M
       proxy:
-        replicas: 2
+        replicas: 1
         scheduleRuleWhenUnsatisfiable: ScheduleAnyway
-      replicas: 3
+      replicas: 1
       scheduleRuleWhenUnsatisfiable: ScheduleAnyway
       storageSize: 8Gi
       timeoutClient: 300
@@ -60,9 +60,9 @@ spec:
         galera:
           wsrep_slave_threads: 3
       proxy:
-        replicas: 2
+        replicas: 1
         scheduleRuleWhenUnsatisfiable: ScheduleAnyway
-      replicas: 3
+      replicas: 1
       scheduleRuleWhenUnsatisfiable: ScheduleAnyway
       storageSize: 8Gi
       timeoutClient: 300
@@ -76,9 +76,9 @@ spec:
         galera:
           wsrep_slave_threads: 3
       proxy:
-        replicas: 2
+        replicas: 1
         scheduleRuleWhenUnsatisfiable: ScheduleAnyway
-      replicas: 3
+      replicas: 1
       scheduleRuleWhenUnsatisfiable: ScheduleAnyway
       storageSize: 8Gi
       timeoutClient: 300
@@ -93,9 +93,9 @@ spec:
           max_connections: 1337
           max_heap_table_size: 64M
       proxy:
-        replicas: 2
+        replicas: 1
         scheduleRuleWhenUnsatisfiable: ScheduleAnyway
-      replicas: 3
+      replicas: 1
       scheduleRuleWhenUnsatisfiable: ScheduleAnyway
       storageSize: 8Gi
       timeoutClient: 300
@@ -122,11 +122,11 @@ spec:
   memcached:
     connections: 1024
     memory: 512
-    replicas: 3
+    replicas: 1
     scheduleRuleWhenUnsatisfiable: ScheduleAnyway
   messageQueue:
     cell1:
-      replicas: 3
+      replicas: 1
       resources:
         rabbitmq:
           limits:
@@ -136,7 +136,7 @@ spec:
       storageSize: 8Gi
       tolerateNodeDown: false
   metadata:
-    replicas: 3
+    replicas: 1
     scheduleRuleWhenUnsatisfiable: ScheduleAnyway
   novaConfig:
     DEFAULT:
@@ -148,7 +148,7 @@ spec:
       ingressClassName: nginx
       port: 443
     publishEndpoint: true
-    replicas: 3
+    replicas: 1
     scheduleRuleWhenUnsatisfiable: ScheduleAnyway
   placementCleanup:
     schedule: 0 0 1 * *
@@ -157,7 +157,7 @@ spec:
   region:
     name: hetzner
   scheduler:
-    replicas: 3
+    replicas: 1
     scheduleRuleWhenUnsatisfiable: ScheduleAnyway
   targetRelease: "2025.1"
   vnc:
@@ -167,5 +167,5 @@ spec:
       ingressClassName: nginx
       port: 443
     publishEndpoint: true
-    replicas: 3
+    replicas: 1
     scheduleRuleWhenUnsatisfiable: ScheduleAnyway

--- a/infrastructure/yaook/octavia.yaml
+++ b/infrastructure/yaook/octavia.yaml
@@ -8,7 +8,7 @@ spec:
   neutronRef:
     name: neutron-ovn
   api:
-    replicas: 3
+    replicas: 1
     ingress:
       createIngress: false
       fqdn: "octavia.rpcu.vpn"
@@ -18,26 +18,26 @@ spec:
   health_manager:
     scheduleRuleWhenUnsatisfiable: ScheduleAnyway
   housekeeping:
-    replicas: 3
+    replicas: 1
   networking:
     # CIDR of the Neutron network to be used to connect Octavia management
     # services and the Amphora VMs. Will be exposed via OVS internal ports
     # on Kubernetes nodes and must not collide with Kubernetes IP ranges!
     managementSubnetCIDR: "172.31.0.0/16"
   database:
-    replicas: 3
+    replicas: 1
     timeoutClient: 300
     proxy:
-      replicas: 3
+      replicas: 1
     backup:
       schedule: "0 * * * *"
   memcached:
     connections: 1024
     memory: 512
-    replicas: 3
+    replicas: 1
     scheduleRuleWhenUnsatisfiable: ScheduleAnyway
   messageQueue:
-    replicas: 3
+    replicas: 1
   issuerRef:
     name: yaook-internal
   targetRelease: "2025.1"


### PR DESCRIPTION
- **chore 🧹 (yaook): reduce replica counts of OpenStack services to 1**
- **chore 🧹 (crossplane-resources): update OpenStack resource external IDs for groups, project, and security group**
- **chore 🧹 (horizon): scale replicas from 1 to 3**
