### PR TITLE
chore 🧹 (crossplane/yaook): remove DNS security group rule from Crossplane and configure dnsmasq DNS servers in Yaook neutron

### DIFF
--- a/infrastructure/crossplane-resources/openstack/securityGroups.yaml
+++ b/infrastructure/crossplane-resources/openstack/securityGroups.yaml
@@ -86,19 +86,3 @@ spec:
     remoteIpPrefix: 0.0.0.0/0
     securityGroupIdRef:
       name: default
----
-apiVersion: networking.openstack.m.crossplane.io/v1alpha1
-kind: SecgroupRuleV2
-metadata:
-  name: allow-dns
-spec:
-  forProvider:
-    description: "Managed by Crossplane - allow-dns"
-    direction: ingress
-    ethertype: IPv4
-    portRangeMax: 53
-    portRangeMin: 53
-    protocol: udp
-    remoteIpPrefix: 0.0.0.0/0
-    securityGroupIdRef:
-      name: default

--- a/infrastructure/yaook/neutron.yaml
+++ b/infrastructure/yaook/neutron.yaml
@@ -34,6 +34,8 @@ spec:
     scheduleRuleWhenUnsatisfiable: ScheduleAnyway
   neutronConfig:
     DEFAULT:
+      dnsmasq_dns_servers:
+        - 172.16.0.254
       debug: false
       global_physnet_mtu: 9000
       advertise_mtu: True


### PR DESCRIPTION
Signed-off-by: Victor Hang <vhvictorhang@gmail.com>
