### PR TITLE
chore 🧹 (nova): limit max concurrent builds to 1

### DIFF
--- a/infrastructure/yaook/nova.yaml
+++ b/infrastructure/yaook/nova.yaml
@@ -141,6 +141,7 @@ spec:
   novaConfig:
     DEFAULT:
       debug: false
+      max_concurrent_builds: 1
       block_device_allocate_retries: 180
       block_device_allocate_retries_interval: 10
     cinder:


### PR DESCRIPTION
Signed-off-by: Victor Hang <vhvictorhang@gmail.com>
