### PR TITLE
feat ✨ (yaook): limit nova compute concurrent builds to 5

### DIFF
--- a/infrastructure/yaook/nova.yaml
+++ b/infrastructure/yaook/nova.yaml
@@ -19,6 +19,7 @@ spec:
         novaComputeConfig:
           DEFAULT:
             debug: false
+            max_concurrent_builds: 5
             block_device_allocate_retries: 180
             block_device_allocate_retries_interval: 10
           cinder:


### PR DESCRIPTION
Signed-off-by: Victor Hang <vhvictorhang@gmail.com>
