### PR TITLE
fix 🐛 (yaook): fix resource key names to match actual container names across operators

### DIFF
--- a/infrastructure/yaook/cinder.yaml
+++ b/infrastructure/yaook/cinder.yaml
@@ -14,7 +14,7 @@ spec:
     replicas: 3
     scheduleRuleWhenUnsatisfiable: ScheduleAnyway
     resources:
-      api:
+      cinder-api:
         requests:
           cpu: 200m
           memory: 512Mi
@@ -49,7 +49,7 @@ spec:
         replicas: 3
         scheduleRuleWhenUnsatisfiable: ScheduleAnyway
         resources:
-          volume:
+          cinder-volume:
             requests:
               cpu: 500m
               memory: 1Gi
@@ -112,7 +112,7 @@ spec:
     replicas: 3
     scheduleRuleWhenUnsatisfiable: ScheduleAnyway
     resources:
-      scheduler:
+      cinder-scheduler:
         requests:
           cpu: 200m
           memory: 512Mi

--- a/infrastructure/yaook/glance.yaml
+++ b/infrastructure/yaook/glance.yaml
@@ -24,7 +24,7 @@ spec:
       fqdn: "glance.rpcu.vpn"
       port: 443
     resources:
-      api:
+      glance-api:
         requests:
           cpu: 200m
           memory: 512Mi

--- a/infrastructure/yaook/keystone.yaml
+++ b/infrastructure/yaook/keystone.yaml
@@ -13,7 +13,9 @@ spec:
     scheduleRuleWhenUnsatisfiable: ScheduleAnyway
     wsgiProcesses: 10
     resources:
-      api:
+      # The container inside the keystone-api Deployment is named "keystone",
+      # not "keystone-api" — yaook source confirms this naming.
+      keystone:
         requests:
           cpu: 200m
           memory: 512Mi

--- a/infrastructure/yaook/neutron.yaml
+++ b/infrastructure/yaook/neutron.yaml
@@ -10,7 +10,7 @@ spec:
       port: 443
     replicas: 3
     resources:
-      api:
+      neutron-api:
         requests:
           cpu: 200m
           memory: 512Mi

--- a/infrastructure/yaook/nova.yaml
+++ b/infrastructure/yaook/nova.yaml
@@ -13,7 +13,7 @@ spec:
     replicas: 3
     scheduleRuleWhenUnsatisfiable: ScheduleAnyway
     resources:
-      api:
+      nova-api:
         requests:
           cpu: 200m
           memory: 512Mi
@@ -53,7 +53,7 @@ spec:
     replicas: 3
     scheduleRuleWhenUnsatisfiable: ScheduleAnyway
     resources:
-      conductor:
+      nova-conductor:
         requests:
           cpu: 200m
           memory: 512Mi
@@ -169,7 +169,7 @@ spec:
     replicas: 3
     scheduleRuleWhenUnsatisfiable: ScheduleAnyway
     resources:
-      metadata:
+      nova-metadata:
         requests:
           cpu: 100m
           memory: 256Mi
@@ -198,7 +198,7 @@ spec:
     replicas: 3
     scheduleRuleWhenUnsatisfiable: ScheduleAnyway
     resources:
-      api:
+      placement:
         requests:
           cpu: 200m
           memory: 512Mi
@@ -215,7 +215,7 @@ spec:
     replicas: 3
     scheduleRuleWhenUnsatisfiable: ScheduleAnyway
     resources:
-      scheduler:
+      nova-scheduler:
         requests:
           cpu: 200m
           memory: 512Mi
@@ -233,7 +233,7 @@ spec:
     replicas: 1
     scheduleRuleWhenUnsatisfiable: ScheduleAnyway
     resources:
-      vnc:
+      nova-novncproxy:
         requests:
           cpu: 100m
           memory: 256Mi


### PR DESCRIPTION
Signed-off-by: Victor Hang <vhvictorhang@gmail.com>
