### PR TITLE
fix 🐛 (openstack-ccm-identity): set OCCM lb-method to SOURCE_IP for OVN compatibility

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -260,7 +260,7 @@ abort the CCM HelmRelease apply (same blast-radius rationale as `capo-identity`)
   (`[Global] use-clouds=true` delegating auth to clouds.yaml; `[LoadBalancer]`
   Octavia config with `floating-network-id` = the Cluster's `externalNetworkId`;
   `lb-provider=ovn` — the mgmt cluster's OpenStack uses the OVN backend, NOT
-  Amphora).
+  Amphora; `lb-method=SOURCE_IP` — OVN does not support ROUND_ROBIN).
 - `README.md` - Rationale, contents, Flux wiring, caveats.
 - `kustomization.yaml` - Kustomization manifest.
 

--- a/infrastructure/openstack-ccm-identity/externalsecret.yaml
+++ b/infrastructure/openstack-ccm-identity/externalsecret.yaml
@@ -58,6 +58,7 @@ spec:
           floating-network-id=1cfd69da-057c-4748-a0d4-de5b0ca77db2
           create-monitor=true
           lb-provider=ovn
+          lb-method=SOURCE_IP
   data:
     - secretKey: cloudsYaml
       remoteRef:


### PR DESCRIPTION
Signed-off-by: Victor Hang <vhvictorhang@gmail.com>
