### PR TITLE
fix 🐛: fix OCCM lb-method to SOURCE_IP_PORT for OVN and correct Designate backend port to 9002

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -260,7 +260,8 @@ abort the CCM HelmRelease apply (same blast-radius rationale as `capo-identity`)
   (`[Global] use-clouds=true` delegating auth to clouds.yaml; `[LoadBalancer]`
   Octavia config with `floating-network-id` = the Cluster's `externalNetworkId`;
   `lb-provider=ovn` — the mgmt cluster's OpenStack uses the OVN backend, NOT
-  Amphora; `lb-method=SOURCE_IP` — OVN does not support ROUND_ROBIN).
+  Amphora; `lb-method=SOURCE_IP_PORT` — OVN does not support ROUND_ROBIN or
+  SOURCE_IP).
 - `README.md` - Rationale, contents, Flux wiring, caveats.
 - `kustomization.yaml` - Kustomization manifest.
 

--- a/infrastructure/openstack-ccm-identity/externalsecret.yaml
+++ b/infrastructure/openstack-ccm-identity/externalsecret.yaml
@@ -46,6 +46,10 @@ spec:
         # for Octavia, NOT Amphora. Without this, the OCCM defaults to Amphora
         # and Octavia rejects the request with "Provider 'amphora' is not
         # enabled".
+        #
+        # lb-method=SOURCE_IP_PORT: OVN does not support ROUND_ROBIN or
+        # SOURCE_IP. SOURCE_IP_PORT is OVN's native load-balancing algorithm
+        # (source IP + port hashing).
         cloud.conf: |
           [Global]
           use-clouds=true
@@ -58,7 +62,7 @@ spec:
           floating-network-id=1cfd69da-057c-4748-a0d4-de5b0ca77db2
           create-monitor=true
           lb-provider=ovn
-          lb-method=SOURCE_IP
+          lb-method=SOURCE_IP_PORT
   data:
     - secretKey: cloudsYaml
       remoteRef:

--- a/infrastructure/yaook/gateway/httproute-designate.yaml
+++ b/infrastructure/yaook/gateway/httproute-designate.yaml
@@ -17,7 +17,7 @@ spec:
             value: /
       backendRefs:
         - name: designate-api
-          port: 32443
+          port: 9002
 ---
 apiVersion: gateway.networking.k8s.io/v1alpha3
 kind: BackendTLSPolicy


### PR DESCRIPTION
Signed-off-by: Victor Hang <vhvictorhang@gmail.com>
