### PR TITLE
fix 🐛 (infrastructure): reduce network MTU from 9000 to 1342 to prevent packet black-holing

### DIFF
--- a/infrastructure/crossplane-compositions/composition-router.yaml
+++ b/infrastructure/crossplane-compositions/composition-router.yaml
@@ -23,7 +23,7 @@ spec:
                 forProvider:
                   adminStateUp: true
                   external: true
-                  mtu: 9000
+                  mtu: 1342
                   shared: true
                   segments:
                     - networkType: flat

--- a/infrastructure/crossplane-resources/openstack/network-default.yaml
+++ b/infrastructure/crossplane-resources/openstack/network-default.yaml
@@ -6,7 +6,7 @@ spec:
   forProvider:
     adminStateUp: true
     shared: true
-    mtu: 8942
+    mtu: 1342
     name: default
 ---
 apiVersion: networking.openstack.m.crossplane.io/v1alpha1


### PR DESCRIPTION
Signed-off-by: Victor Hang <vhvictorhang@gmail.com>
