### PR TITLE
fix 🐛 (chihiro): use cross-namespace SecretStore with dedicated reader RBAC for OIDC secret sync

### DIFF
--- a/clusters/mgmt/apps/chihiro/externalsecret.yaml
+++ b/clusters/mgmt/apps/chihiro/externalsecret.yaml
@@ -1,5 +1,62 @@
-# Syncs the chihiro OIDC connection secret from Crossplane's namespace
-# (crossplane-system) into chihiro's namespace (chihiro-system).
+# Syncs the chihiro OIDC connection secret produced by Crossplane (the Zitadel
+# Oidc resource writes clientId/clientSecret to `chihiro-oidc` in
+# crossplane-system) into chihiro's namespace (chihiro-system).
+#
+# Cross-namespace reads with the External Secrets Kubernetes provider are
+# configured on the SecretStore via `provider.kubernetes.remoteNamespace` (the
+# per-remoteRef `namespace` field does NOT exist in the v1 schema). Auth is a
+# dedicated reader ServiceAccount in chihiro-system, granted read access to the
+# `chihiro-oidc` secret via a Role/RoleBinding in crossplane-system.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: chihiro-oidc-reader
+  namespace: chihiro-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: chihiro-oidc-reader
+  namespace: crossplane-system
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    resourceNames: ["chihiro-oidc"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: chihiro-oidc-reader
+  namespace: crossplane-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: chihiro-oidc-reader
+subjects:
+  - kind: ServiceAccount
+    name: chihiro-oidc-reader
+    namespace: chihiro-system
+---
+# SecretStore reading from crossplane-system on this cluster's API.
+apiVersion: external-secrets.io/v1
+kind: SecretStore
+metadata:
+  name: crossplane-system-secrets
+  namespace: chihiro-system
+spec:
+  provider:
+    kubernetes:
+      remoteNamespace: crossplane-system
+      server:
+        caProvider:
+          type: ConfigMap
+          name: kube-root-ca.crt
+          key: ca.crt
+      auth:
+        serviceAccount:
+          name: chihiro-oidc-reader
+---
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
@@ -8,7 +65,7 @@ metadata:
 spec:
   refreshInterval: 1h
   secretStoreRef:
-    name: kubernetes
+    name: crossplane-system-secrets
     kind: SecretStore
   target:
     name: chihiro-oidc
@@ -17,20 +74,8 @@ spec:
     - secretKey: clientId
       remoteRef:
         key: chihiro-oidc
-        namespace: crossplane-system
         property: clientId
     - secretKey: clientSecret
       remoteRef:
         key: chihiro-oidc
-        namespace: crossplane-system
         property: clientSecret
----
-# Local SecretStore reading from this cluster's API.
-apiVersion: external-secrets.io/v1
-kind: SecretStore
-metadata:
-  name: kubernetes
-  namespace: chihiro-system
-spec:
-  provider:
-    kubernetes: {}


### PR DESCRIPTION
Signed-off-by: Victor Hang <vhvictorhang@gmail.com>
