### PR TITLE
fix 🐛 (cluster-api-templates): open NodePort range in managed SGs for Octavia LoadBalancer connectivity

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -486,10 +486,10 @@ is a ClusterClass variable injected via patches, so creating a new cluster is a
 small `Cluster` CR (no template forking). See `README.md` for the variable table
 and the `-vN` immutability/rotation workflow.
 
-- `clusterclass.yaml` - ClusterClass `openstack-default` (renamed from `openstack-mgmt`) with variables: identityRef, externalNetworkId, managedSubnetCIDR, managedSubnetAllocationPools, imageName, controlPlaneFlavor, workerFlavor, sshKeyName, apiServerFloatingIP. Template refs use the versioned `openstack-default-*-v1` names.
+- `clusterclass.yaml` - ClusterClass `openstack-default` (renamed from `openstack-mgmt`) with variables: identityRef, externalNetworkId, managedSubnetCIDR, managedSubnetAllocationPools, imageName, controlPlaneFlavor, workerFlavor, sshKeyName, apiServerFloatingIP. Template refs use the versioned `openstack-default-*-v1` names, except `infrastructure.templateRef` which now points at `openstack-default-cluster-v2` (NodePort SG rotation, see below).
 - `templates/controlplane.yaml` - KubeadmControlPlaneTemplate `openstack-default-control-plane-v1`
 - `templates/bootstrap.yaml` - KubeadmConfigTemplate `openstack-default-worker-v1`
-- `templates/infracluster.yaml` - OpenStackClusterTemplate `openstack-default-cluster-v1`. The `managedSecurityGroups` sets `allowAllInClusterTraffic: true` plus explicit Cilium data-plane rules (VXLAN UDP 8472, health TCP 4240, Hubble TCP 4244, ICMP via `remoteManagedGroups: [controlplane, worker]`) — required because CAPO's default managed SGs only open API/etcd/kubelet/node-port and would otherwise drop Cilium's cross-node overlay (see note in Cluster Safety). `identityRef` is hardcoded to `mgmt-cloud-config` (CAPO requires it at admission time); the ClusterClass `identityRef` variable/patch overrides this default per-cluster when the topology controller synthesizes the concrete `OpenStackCluster`.
+- `templates/infracluster.yaml` - OpenStackClusterTemplate `openstack-default-cluster-v1` **and** `-v2`. The `managedSecurityGroups` sets `allowAllInClusterTraffic: true` plus explicit Cilium data-plane rules (VXLAN UDP 8472, health TCP 4240, Hubble TCP 4244, ICMP via `remoteManagedGroups: [controlplane, worker]`) — required because CAPO's default managed SGs only open API/etcd/kubelet/node-port and would otherwise drop Cilium's cross-node overlay (see note in Cluster Safety). **`-v2` additionally opens the Kubernetes NodePort range (TCP 30000–32767 from `0.0.0.0/0`)** — REQUIRED for external `type: LoadBalancer` Services via the OpenStack CCM + Octavia (the Octavia/OVN VIP DNATs to `<node IP>:<nodePort>`; without this rule the managed SG drops it and the LB floating IP times out at the TCP layer despite correct VIP/floating-IP/DNS). The ClusterClass points `infrastructure.templateRef` at `-v2`; `-v1` is retained only until the rotation is confirmed, then deleted (per the README `-vN` workflow — an `OpenStackClusterTemplate` rotation reconciles the SGs onto the live `OpenStackCluster` without rolling machines). `identityRef` is hardcoded to `mgmt-cloud-config` (CAPO requires it at admission time); the ClusterClass `identityRef` variable/patch overrides this default per-cluster when the topology controller synthesizes the concrete `OpenStackCluster`.
 - `templates/machines.yaml` - OpenStackMachineTemplate `openstack-default-control-plane-v1` and `openstack-default-worker-v1` (flavor/image are `dummy` placeholders overwritten by patches)
 - `namespace.yaml` - Namespace `mgmt`
 - `README.md` - Structure, variable table, credentials/ESO note, new-cluster recipe, and immutability/`-vN` rotation workflow
@@ -1070,6 +1070,32 @@ If Cilium is switched to Geneve, open UDP 6081 instead of 8472; if Cilium
 encryption is enabled, also open WireGuard/ESP. After changing this, verify the
 rules actually landed on the managed SGs:
 `openstack security group rule list k8s-cluster-mgmt-mgmt-secgroup-controlplane`.
+
+#### CAPO managed security groups must open the NodePort range for Octavia LoadBalancer (mgmt cluster)
+
+A second, distinct gap in CAPO's default managed SGs: they do **not** open the
+Kubernetes Service **NodePort range (30000–32767)** from outside the cluster.
+On mgmt, external `type: LoadBalancer` Services are provisioned by the OpenStack
+CCM via Octavia (OVN provider). The Octavia VIP DNATs incoming traffic to a
+member = `<node IP>:<nodePort>`. Without a NodePort ingress rule the managed SG
+silently drops that, so the LoadBalancer **floating IP times out at the TCP
+layer** (`curl: (28) Failed to connect ... Connection timed out`) even though
+the Octavia VIP, the floating IP, and the DNS record are all correct. This is
+the failure that made the kgateway `https` Gateway (the cluster's only
+`type: LoadBalancer` service, floating IP `172.16.255.111`) unreachable while
+every other endpoint resolved fine.
+
+Fix: `openstack-default-cluster-v2` in
+`infrastructure/cluster-api-templates/templates/infracluster.yaml` adds an
+ingress rule opening **TCP 30000–32767 from `0.0.0.0/0`** (source can't be
+scoped — the OVN VIP may preserve the original client source IP with
+`lb-method=SOURCE_IP_PORT`). Because `OpenStackClusterTemplate.spec.template.spec`
+is immutable once referenced, this is a NEW `-v2` template with the ClusterClass
+`infrastructure.templateRef` repointed to it (the documented `-vN` rotation) —
+NOT an in-place edit of `-v1`. The rotation reconciles the SGs onto the live
+`OpenStackCluster` without rolling machines; delete `-v1` once confirmed. Verify
+with `openstack security group rule list k8s-cluster-mgmt-mgmt-secgroup-worker`
+(and `…-controlplane`).
 
 Note: MTU is a separate, secondary concern. Double encapsulation (Cilium VXLAN
 over Neutron VXLAN/Geneve) shrinks the usable pod MTU; large packets (DNS/TCP,

--- a/infrastructure/cluster-api-templates/README.md
+++ b/infrastructure/cluster-api-templates/README.md
@@ -149,5 +149,17 @@ This keeps the change explicit, auditable, and safely rolled out via GitOps.
   data-plane (VXLAN 8472, health 4240, Hubble 4244, ICMP) on top of
   `allowAllInClusterTraffic: true`. See the root `AGENTS.md` ("CAPO managed
   security groups must open the Cilium overlay") for why this is mandatory.
+- `infracluster.yaml` now also carries `openstack-default-cluster-v2`, which is
+  identical to `-v1` plus an ingress rule opening the Kubernetes **NodePort
+  range (TCP 30000–32767, from `0.0.0.0/0`)**. This is REQUIRED for external
+  `type: LoadBalancer` Services on clusters that use the OpenStack CCM + Octavia
+  (e.g. mgmt): the Octavia/OVN VIP forwards traffic to `<node IP>:<nodePort>`,
+  and CAPO's default managed SGs do not open that range — so without it the LB
+  floating IP times out at the TCP layer even though the VIP, floating IP and
+  DNS are all correct. The ClusterClass `infrastructure.templateRef` points at
+  `-v2`; `-v1` is retained only until the rotation is confirmed, then deleted
+  (this is exactly the `-vN` workflow above — an `OpenStackClusterTemplate`
+  rotation reconciles the SGs onto the live `OpenStackCluster` without rolling
+  machines).
 - Machine `flavor`/`image` in `machines.yaml` are deliberate `dummy`
   placeholders — they are always overwritten by patches.

--- a/infrastructure/cluster-api-templates/clusterclass.yaml
+++ b/infrastructure/cluster-api-templates/clusterclass.yaml
@@ -37,7 +37,7 @@ spec:
     templateRef:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
       kind: OpenStackClusterTemplate
-      name: openstack-default-cluster-v1
+      name: openstack-default-cluster-v2
 
   # ---------------------------------------------------------------------------
   # Worker topology

--- a/infrastructure/cluster-api-templates/templates/infracluster.yaml
+++ b/infrastructure/cluster-api-templates/templates/infracluster.yaml
@@ -17,6 +17,13 @@
 # referenced. The managedSecurityGroups block below is intentionally part of the
 # base (not a patch) because it is the same for every Cilium cluster. To change
 # the SG rules (or identityRef), bump to -v2 and repoint infrastructure.templateRef.
+#
+# -v1 is RETAINED (unreferenced) only for the duration of the rotation to -v2.
+# The ClusterClass now points at -v2 (adds the NodePort-range ingress rule so the
+# OpenStack Octavia/OVN LoadBalancer can reach Service NodePorts — without it,
+# externally-exposed `type: LoadBalancer` services time out at the TCP layer:
+# the Octavia VIP DNATs to a node IP:nodePort that the managed SG was dropping).
+# Once -v2 has reconciled and LoadBalancer connectivity is confirmed, delete -v1.
 # -----------------------------------------------------------------------------
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: OpenStackClusterTemplate
@@ -119,3 +126,123 @@ spec:
             remoteManagedGroups:
               - controlplane
               - worker
+---
+# -----------------------------------------------------------------------------
+# openstack-default-cluster-v2
+#
+# Identical to -v1 plus a NodePort-range ingress rule. CAPO's default managed
+# security groups do NOT open the Service NodePort range (30000-32767) from
+# outside the cluster. With an external `type: LoadBalancer` Service, the
+# OpenStack Cloud Controller Manager provisions an Octavia (OVN provider) load
+# balancer whose VIP DNATs incoming traffic to a member = <node IP>:<nodePort>.
+# Because the managed SG dropped that nodePort ingress, the TCP handshake to the
+# LoadBalancer floating IP never completed (curl: "Connection timed out") even
+# though the VIP, floating IP and DNS were all correct.
+#
+# The rule below opens the kube-proxy/Cilium default NodePort range for TCP from
+# anywhere. Source is 0.0.0.0/0 because the Octavia OVN VIP may forward with the
+# original client source IP preserved (lb-method SOURCE_IP_PORT), so the member
+# ingress cannot be scoped to a single LB address. This matches the standard
+# requirement for externally-reachable NodePort-backed LoadBalancer services.
+#
+# IMMUTABILITY: this is a NEW template (not an in-place edit of -v1). The
+# ClusterClass infrastructure.templateRef is repointed to -v2; -v1 is deleted
+# once the rotation is confirmed (see README "-vN rotation workflow").
+# -----------------------------------------------------------------------------
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: OpenStackClusterTemplate
+metadata:
+  name: openstack-default-cluster-v2
+  namespace: mgmt
+spec:
+  template:
+    spec:
+      apiServerLoadBalancer:
+        enabled: true
+      identityRef:
+        name: mgmt-cloud-config
+        cloudName: openstack
+      managedSecurityGroups:
+        # See -v1 above for the rationale behind allowAllInClusterTraffic and the
+        # Cilium data-plane rules. -v2 only ADDS the NodePort-range rule.
+        allowAllInClusterTraffic: true
+        allNodesSecurityGroupRules:
+          - description: Allow SSH ingress from anywhere
+            direction: ingress
+            etherType: IPv4
+            name: SSH ingress
+            portRangeMax: 22
+            portRangeMin: 22
+            protocol: tcp
+            remoteIPPrefix: 0.0.0.0/0
+          - description: Allow DNS egress (UDP) to anywhere
+            direction: egress
+            etherType: IPv4
+            name: DNS egress (UDP)
+            portRangeMax: 53
+            portRangeMin: 53
+            protocol: udp
+            remoteIPPrefix: 0.0.0.0/0
+          - description: Allow DNS egress (TCP) to anywhere
+            direction: egress
+            etherType: IPv4
+            name: DNS egress (TCP)
+            portRangeMax: 53
+            portRangeMin: 53
+            protocol: tcp
+            remoteIPPrefix: 0.0.0.0/0
+          # ---------------------------------------------------------------
+          # Cilium data-plane between nodes. (See -v1 for full rationale.)
+          # ---------------------------------------------------------------
+          - description: Cilium VXLAN overlay (node-to-node)
+            direction: ingress
+            etherType: IPv4
+            name: Cilium VXLAN
+            portRangeMax: 8472
+            portRangeMin: 8472
+            protocol: udp
+            remoteManagedGroups:
+              - controlplane
+              - worker
+          - description: Cilium health checks (node-to-node)
+            direction: ingress
+            etherType: IPv4
+            name: Cilium health (TCP 4240)
+            portRangeMax: 4240
+            portRangeMin: 4240
+            protocol: tcp
+            remoteManagedGroups:
+              - controlplane
+              - worker
+          - description: Hubble relay/peer (node-to-node)
+            direction: ingress
+            etherType: IPv4
+            name: Cilium Hubble (TCP 4244)
+            portRangeMax: 4244
+            portRangeMin: 4244
+            protocol: tcp
+            remoteManagedGroups:
+              - controlplane
+              - worker
+          - description: ICMP between nodes (health/path MTU)
+            direction: ingress
+            etherType: IPv4
+            name: ICMP (node-to-node)
+            protocol: icmp
+            remoteManagedGroups:
+              - controlplane
+              - worker
+          # ---------------------------------------------------------------
+          # Kubernetes NodePort range — REQUIRED for external `type:
+          # LoadBalancer` Services routed via the OpenStack CCM + Octavia.
+          # The Octavia VIP forwards to <node IP>:<nodePort>; without this
+          # ingress the managed SG drops it and the LB times out.
+          # ---------------------------------------------------------------
+          - description: Kubernetes NodePort services (Octavia LoadBalancer backends)
+            direction: ingress
+            etherType: IPv4
+            name: NodePort range (TCP)
+            portRangeMax: 32767
+            portRangeMin: 30000
+            protocol: tcp
+            remoteIPPrefix: 0.0.0.0/0


### PR DESCRIPTION
Signed-off-by: Victor Hang <vhvictorhang@gmail.com>
