### PR TITLE
docs 📚 (cluster-api-templates): document per-pool workerFlavor overrides for heterogeneous worker pools

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -634,7 +634,23 @@ and the `-vN` immutability/rotation workflow.
 - `templates/infracluster.yaml` - OpenStackClusterTemplate `openstack-default-cluster-v1` **and** `-v2`. The `managedSecurityGroups` sets `allowAllInClusterTraffic: true` plus explicit Cilium data-plane rules (VXLAN UDP 8472, health TCP 4240, Hubble TCP 4244, ICMP via `remoteManagedGroups: [controlplane, worker]`) — required because CAPO's default managed SGs only open API/etcd/kubelet/node-port and would otherwise drop Cilium's cross-node overlay (see note in Cluster Safety). **`-v2` additionally opens the Kubernetes NodePort range (TCP 30000–32767 from `0.0.0.0/0`)** — REQUIRED for external `type: LoadBalancer` Services via the OpenStack CCM + Octavia (the Octavia/OVN VIP DNATs to `<node IP>:<nodePort>`; without this rule the managed SG drops it and the LB floating IP times out at the TCP layer despite correct VIP/floating-IP/DNS). The ClusterClass points `infrastructure.templateRef` at `-v2`; `-v1` is retained only until the rotation is confirmed, then deleted (per the README `-vN` workflow — an `OpenStackClusterTemplate` rotation reconciles the SGs onto the live `OpenStackCluster` without rolling machines). `identityRef` is hardcoded to `mgmt-cloud-config` (CAPO requires it at admission time); the ClusterClass `identityRef` variable/patch overrides this default per-cluster when the topology controller synthesizes the concrete `OpenStackCluster`.
 - `templates/machines.yaml` - OpenStackMachineTemplate `openstack-default-control-plane-v1` and `openstack-default-worker-v1` (flavor/image are `dummy` placeholders overwritten by patches)
 - `namespace.yaml` - Namespace `mgmt`
-- `README.md` - Structure, variable table, credentials/ESO note, new-cluster recipe, and immutability/`-vN` rotation workflow
+- `README.md` - Structure, variable table, credentials/ESO note, new-cluster recipe, immutability/`-vN` rotation workflow, and **"Multiple worker pools with different flavors"** (per-pool `workerFlavor` overrides)
+
+> **Multiple worker pools / per-pool flavors.** Both ClusterClasses
+> (`openstack-default` and `openstack-kamaji`) expose a single `default-worker`
+> machine-deployment class, and the `workerFlavor` patch targets that class (not
+> a specific pool). A `Cluster` CR can therefore instantiate `default-worker`
+> any number of times under `spec.topology.workers.machineDeployments[]` and set
+> a different flavor per pool via `machineDeployments[].variables.overrides`
+> (`name: workerFlavor`, `value: <flavor>`). A pool that omits the override
+> inherits the top-level `workerFlavor` (default `xlarge`). No extra worker
+> classes or template rotation are needed — this is the idiomatic CAPI
+> per-MachineDeployment variable-override mechanism. Other worker-class variables
+> (`imageName`, `sshKeyName`) can be overridden the same way; `controlPlaneFlavor`
+> and cluster-wide values (e.g. `externalNetworkId`) cannot be per-pool. See the
+> README section for a full example. The same comment is inlined above the
+> `workerFlavor` patch in both `clusterclass.yaml` and `clusterclass-kamaji.yaml`.
+
 - `kustomization.yaml` - Kustomization manifest (references namespace, clusterclass, and all four `templates/*` files). The actual `Cluster` CR lives at `clusters/mgmt/clusters/mgmt.yaml` and now references `classRef.name: openstack-default` (and no longer sets an `identityRef` variable).
 
 > The OpenStack credentials secret (`mgmt-cloud-config`) consumed by the hardcoded

--- a/infrastructure/cluster-api-templates/README.md
+++ b/infrastructure/cluster-api-templates/README.md
@@ -45,7 +45,7 @@ Set these in a `Cluster` `spec.topology.variables`:
 | `managedSubnetCIDR`            | no       | `192.168.1.0/24`  | CIDR for the managed node subnet                                |
 | `managedSubnetAllocationPools` | no       | `.11`–`.254`      | DHCP allocation ranges (leaves low IPs free for manual ports)   |
 | `controlPlaneFlavor`           | no       | `large`           | OpenStack flavor for control-plane machines                     |
-| `workerFlavor`                 | no       | `xlarge`          | OpenStack flavor for worker machines                            |
+| `workerFlavor`                 | no       | `xlarge`          | OpenStack flavor for worker machines (per-pool overridable)     |
 | `sshKeyName`                   | no       | `""` (off)        | Existing OpenStack keypair to inject (patch disabled if empty)  |
 | `apiServerFloatingIP`          | no       | auto-allocated    | Pin a specific floating IP to the API server LB                 |
 | `oidc`                         | no       | `{enabled:false}` | kube-apiserver OIDC via the shared Zitadel "kubernetes" client  |
@@ -53,6 +53,54 @@ Set these in a `Cluster` `spec.topology.variables`:
 Topology-level knobs that are _not_ class variables (set them directly under
 `spec.topology`): Kubernetes `version`, control-plane `replicas`, and each
 `machineDeployments[].replicas`.
+
+### Multiple worker pools with different flavors
+
+> Applies to **both** ClusterClasses — `openstack-default` and `openstack-kamaji`
+> share the same `default-worker` class and `workerFlavor` patch.
+
+`workerFlavor` is a normal class variable, and the `workerFlavor` patch targets
+the `default-worker` machine-deployment class. CAPI lets you instantiate the
+**same class any number of times** as separate `machineDeployments` and
+**override** a class variable per-pool via `variables.overrides`. So you do not
+need extra worker classes to mix flavors — just add more `machineDeployments`
+entries and override `workerFlavor` on each:
+
+```yaml
+workers:
+  machineDeployments:
+    # General-purpose pool — uses the class default workerFlavor (xlarge)
+    - class: default-worker
+      name: md-general
+      replicas: 3
+    # Memory-optimised pool — overrides the flavor for THIS pool only
+    - class: default-worker
+      name: md-bigmem
+      replicas: 2
+      variables:
+        overrides:
+          - name: workerFlavor
+            value: xxlarge
+    # GPU pool — different flavor again
+    - class: default-worker
+      name: md-gpu
+      replicas: 1
+      variables:
+        overrides:
+          - name: workerFlavor
+            value: gpu-a100
+```
+
+Each pool becomes its own `MachineDeployment` with independent `replicas`,
+flavor, scaling, and rolling-update lifecycle. A pool that omits the override
+inherits the top-level `workerFlavor` (or the class default `xlarge`). Any
+other class variable that targets `default-worker` — e.g. `imageName`,
+`sshKeyName` — can be overridden the same way for heterogeneous pools.
+
+> Per-pool `variables.overrides` only work for variables whose patch selects the
+> worker class. `controlPlaneFlavor` cannot be overridden per worker pool (it
+> targets the control plane); cluster-wide values like `externalNetworkId` are
+> not per-pool either.
 
 ### kube-apiserver OIDC (`oidc`)
 
@@ -159,6 +207,15 @@ spec:
         - class: default-worker
           name: md-0
           replicas: 3
+        # Optional extra pool with a different flavor (see "Multiple worker
+        # pools with different flavors" above):
+        # - class: default-worker
+        #   name: md-bigmem
+        #   replicas: 2
+        #   variables:
+        #     overrides:
+        #       - name: workerFlavor
+        #         value: xxlarge
     variables:
       - name: identityRef
         value: { name: my-cloud-config, cloudName: openstack }

--- a/infrastructure/cluster-api-templates/clusterclass-kamaji.yaml
+++ b/infrastructure/cluster-api-templates/clusterclass-kamaji.yaml
@@ -296,6 +296,12 @@ spec:
               valueFrom:
                 variable: imageName
 
+    # workerFlavor sets the flavor for the default-worker machine-deployment
+    # class. Because the patch targets that class (not a specific pool), a
+    # Cluster can instantiate `default-worker` multiple times and override
+    # workerFlavor per-pool via machineDeployments[].variables.overrides —
+    # giving heterogeneous worker pools (different flavors) without extra
+    # classes. See README "Multiple worker pools with different flavors".
     - name: workerFlavor
       definitions:
         - selector:

--- a/infrastructure/cluster-api-templates/clusterclass.yaml
+++ b/infrastructure/cluster-api-templates/clusterclass.yaml
@@ -296,6 +296,12 @@ spec:
               valueFrom:
                 variable: controlPlaneFlavor
 
+    # workerFlavor sets the flavor for the default-worker machine-deployment
+    # class. Because the patch targets that class (not a specific pool), a
+    # Cluster can instantiate `default-worker` multiple times and override
+    # workerFlavor per-pool via machineDeployments[].variables.overrides —
+    # giving heterogeneous worker pools (different flavors) without extra
+    # classes. See README "Multiple worker pools with different flavors".
     - name: workerFlavor
       definitions:
         - selector:


### PR DESCRIPTION
Signed-off-by: Victor Hang <vhvictorhang@gmail.com>
