### PR TITLE
fix 🐛 (crossplane): fix escaped dot in clouds.yaml property reference

### DIFF
--- a/clusters/mgmt/crossplane/openstack/credentials-eso.yaml
+++ b/clusters/mgmt/crossplane/openstack/credentials-eso.yaml
@@ -87,4 +87,4 @@ spec:
     - secretKey: clouds_yaml
       remoteRef:
         key: capo-variables
-        property: clouds\.yaml
+        property: clouds.yaml


### PR DESCRIPTION
Signed-off-by: Victor Hang <vhvictorhang@gmail.com>
