### PR TITLE
fix 🐛 (crossplane): add missing kind to providerConfigRef in RoleAssignments and CCM credential composition

### DIFF
--- a/clusters/mgmt/crossplane/openstack/roleassignments-lab.yaml
+++ b/clusters/mgmt/crossplane/openstack/roleassignments-lab.yaml
@@ -20,6 +20,7 @@ spec:
     projectId: "e538e6c8466945b4bd07da85a7ee004e"
   providerConfigRef:
     name: default
+    kind: ClusterProviderConfig
 ---
 apiVersion: identity.openstack.m.crossplane.io/v1alpha1
 kind: RoleAssignmentV3
@@ -34,6 +35,7 @@ spec:
     projectId: "e538e6c8466945b4bd07da85a7ee004e"
   providerConfigRef:
     name: default
+    kind: ClusterProviderConfig
 ---
 apiVersion: identity.openstack.m.crossplane.io/v1alpha1
 kind: RoleAssignmentV3
@@ -48,3 +50,4 @@ spec:
     projectId: "e538e6c8466945b4bd07da85a7ee004e"
   providerConfigRef:
     name: default
+    kind: ClusterProviderConfig

--- a/clusters/mgmt/crossplane/openstack/roleassignments-production.yaml
+++ b/clusters/mgmt/crossplane/openstack/roleassignments-production.yaml
@@ -12,6 +12,7 @@ spec:
     projectId: "75aa5d153361400488a2d43a4fe629c3"
   providerConfigRef:
     name: default
+    kind: ClusterProviderConfig
 ---
 apiVersion: identity.openstack.m.crossplane.io/v1alpha1
 kind: RoleAssignmentV3
@@ -26,6 +27,7 @@ spec:
     projectId: "75aa5d153361400488a2d43a4fe629c3"
   providerConfigRef:
     name: default
+    kind: ClusterProviderConfig
 ---
 apiVersion: identity.openstack.m.crossplane.io/v1alpha1
 kind: RoleAssignmentV3
@@ -40,3 +42,4 @@ spec:
     projectId: "75aa5d153361400488a2d43a4fe629c3"
   providerConfigRef:
     name: default
+    kind: ClusterProviderConfig

--- a/infrastructure/crossplane-compositions/composition-ccm-credential.yaml
+++ b/infrastructure/crossplane-compositions/composition-ccm-credential.yaml
@@ -42,6 +42,7 @@ spec:
                   userId: "44b2b48fb89d4fde9d659bf01831d3b0"
                 providerConfigRef:
                   name: default
+                  kind: ClusterProviderConfig
             patches:
               - type: FromCompositeFieldPath
                 fromFieldPath: spec.projectId
@@ -58,6 +59,7 @@ spec:
                   userId: "44b2b48fb89d4fde9d659bf01831d3b0"
                 providerConfigRef:
                   name: default
+                  kind: ClusterProviderConfig
             patches:
               - type: FromCompositeFieldPath
                 fromFieldPath: spec.projectId
@@ -74,6 +76,7 @@ spec:
                   userId: "44b2b48fb89d4fde9d659bf01831d3b0"
                 providerConfigRef:
                   name: default
+                  kind: ClusterProviderConfig
             patches:
               - type: FromCompositeFieldPath
                 fromFieldPath: spec.projectId
@@ -91,6 +94,8 @@ spec:
                     - member
                     - reader
                   unrestricted: false
+                providerConfigRef:
+                  kind: ClusterProviderConfig
                 writeConnectionSecretToRef:
                   namespace: crossplane-system
             patches:


### PR DESCRIPTION
Signed-off-by: Victor Hang <vhvictorhang@gmail.com>
