### PR TITLE
fix 🐛 (ccm-credential): Remove hardcoded namespace from writeConnectionSecretToRef

### DIFF
--- a/infrastructure/crossplane-compositions/composition-ccm-credential.yaml
+++ b/infrastructure/crossplane-compositions/composition-ccm-credential.yaml
@@ -97,7 +97,6 @@ spec:
                 providerConfigRef:
                   kind: ClusterProviderConfig
                 writeConnectionSecretToRef:
-                  namespace: crossplane-system
             patches:
               - type: FromCompositeFieldPath
                 fromFieldPath: spec.projectName


### PR DESCRIPTION
Signed-off-by: Victor Hang <vhvictorhang@gmail.com>
