### PR TITLE
fix 🐛 (crossplane-compositions): add missing name field to writeConnectionSecretToRef in ccm-credential composition

### DIFF
--- a/infrastructure/crossplane-compositions/composition-ccm-credential.yaml
+++ b/infrastructure/crossplane-compositions/composition-ccm-credential.yaml
@@ -97,6 +97,7 @@ spec:
                 providerConfigRef:
                   kind: ClusterProviderConfig
                 writeConnectionSecretToRef:
+                  name: placeholder
             patches:
               - type: FromCompositeFieldPath
                 fromFieldPath: spec.projectName


### PR DESCRIPTION
Signed-off-by: Victor Hang <vhvictorhang@gmail.com>
