### PR TITLE
chore 🧹 (chihiro): bump chihiro to v0.4.3 and drop stale v1.35.4 from 26.05 image versions

### DIFF
--- a/clusters/mgmt/apps/chihiro/cm.yaml
+++ b/clusters/mgmt/apps/chihiro/cm.yaml
@@ -136,7 +136,7 @@ data:
               versions: ["v1.35.4"]
             - value: "hephaestus-kaas-26.05-{{ chihiro.version }}"
               label: "26.05"
-              versions: ["v1.36.1", "v1.35.4"]
+              versions: ["v1.36.1"]
           default: "hephaestus-kaas-26.05-{{ chihiro.version }}"
         managedSubnetCIDR:
           label: "Managed Subnet CIDR"

--- a/clusters/mgmt/apps/chihiro/deploy.yaml
+++ b/clusters/mgmt/apps/chihiro/deploy.yaml
@@ -22,7 +22,7 @@ spec:
             - --config=/config.yaml
           command:
             - /chihiro
-          image: zot.bealv.io/public/chihiro:v0.4.2
+          image: zot.bealv.io/public/chihiro:v0.4.3
           ports:
             - containerPort: 8080
               name: http


### PR DESCRIPTION
Signed-off-by: Victor Hang <vhvictorhang@gmail.com>
