### PR TITLE
perf ⚡️ (fluxcd): tune Flux controllers concurrency to default (4) with API rate limits to bound etcd load

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -563,7 +563,8 @@ matchLabels: {type: workload, sveltos.argus.rpcu.io/cilium: enabled}`) that push
     `FluxInstance` CRD ships with the operator, so the operator must land first.
 
   The FluxInstance mirrors `infrastructure/fluxcd/instances/flux.yaml` (all four
-  components incl. `notification-controller`, the `concurrent=42` patch) with
+  components incl. `notification-controller`, the `--concurrent=4` +
+  `--kube-api-qps=50`/`--kube-api-burst=100` throttle patch) with
   `cluster.domain` patched per-cluster to `{{ .Cluster.metadata.name }}.local` and
   a **real `sync` block** pointing at `https://github.com/RPCU/argus.git`
   `refs/heads/main` path **`./infrastructure/fluxcd/operator`** — so **Flux
@@ -859,7 +860,7 @@ _fluxcd/operator/_ - Operator installation
 
 _fluxcd/instances/_ - Instance configuration
 
-- `flux.yaml` - FluxInstance CRD (Flux 2.x, 42 concurrent operations)
+- `flux.yaml` - FluxInstance CRD (Flux 2.x, kustomize/helm controllers patched to `--concurrent=4` + `--kube-api-qps=50`/`--kube-api-burst=100` to bound etcd load)
 - `kustomization.yaml` - Manifest collection
 
 ---
@@ -967,7 +968,7 @@ _fluxcd/instances/_ - Instance configuration
 - **Git Repository**: <https://github.com/RPCU/argus.git>
 - **Branch**: main
 - **Path**: ./clusters/PLACEHOLDER (cluster-specific override)
-- **Concurrency**: 42 operations per controller
+- **Concurrency**: 4 operations per controller (kustomize/helm), throttled with `--kube-api-qps=50`/`--kube-api-burst=100` to bound apiserver/etcd load
 - **Interval**: 1 minute
 
 ### Cluster Network Configuration (clusters/openstack/)

--- a/infrastructure/fluxcd/instances/flux.yaml
+++ b/infrastructure/fluxcd/instances/flux.yaml
@@ -19,13 +19,24 @@ spec:
     domain: "cluster.local"
   kustomize:
     patches:
+      # Tuned down from --concurrent=42 (~10x default) which overloaded etcd:
+      # each concurrent reconcile drives server-side-apply diffs (list/get/patch)
+      # against the apiserver/etcd. Reset to the Flux default concurrency (4) and
+      # cap the per-controller apiserver request rate (--kube-api-qps/--kube-api-burst)
+      # to bound etcd load across all clusters.
       - target:
           kind: Deployment
           name: "(kustomize-controller|helm-controller)"
         patch: |
           - op: add
             path: /spec/template/spec/containers/0/args/-
-            value: --concurrent=42
+            value: --concurrent=4
+          - op: add
+            path: /spec/template/spec/containers/0/args/-
+            value: --kube-api-qps=50
+          - op: add
+            path: /spec/template/spec/containers/0/args/-
+            value: --kube-api-burst=100
   sync:
     kind: GitRepository
     url: "https://github.com/RPCU/argus.git"

--- a/infrastructure/sveltos/clusterprofiles/capi-management.yaml
+++ b/infrastructure/sveltos/clusterprofiles/capi-management.yaml
@@ -511,13 +511,22 @@ data:
             domain: "{{ .Cluster.metadata.name }}.local"
           kustomize:
             patches:
+              # Tuned down from --concurrent=42 (~10x default) which overloaded
+              # etcd. Reset to the Flux default concurrency (4) and cap the
+              # per-controller apiserver request rate to bound etcd load.
               - target:
                   kind: Deployment
                   name: "(kustomize-controller|helm-controller)"
                 patch: |
                   - op: add
                     path: /spec/template/spec/containers/0/args/-
-                    value: --concurrent=42
+                    value: --concurrent=4
+                  - op: add
+                    path: /spec/template/spec/containers/0/args/-
+                    value: --kube-api-qps=50
+                  - op: add
+                    path: /spec/template/spec/containers/0/args/-
+                    value: --kube-api-burst=100
           sync:
             kind: GitRepository
             url: "https://github.com/RPCU/argus.git"

--- a/infrastructure/sveltos/clusterprofiles/flux.yaml
+++ b/infrastructure/sveltos/clusterprofiles/flux.yaml
@@ -98,13 +98,22 @@ data:
         domain: "{{ .Cluster.metadata.name }}.local"
       kustomize:
         patches:
+          # Tuned down from --concurrent=42 (~10x default) which overloaded etcd.
+          # Reset to the Flux default concurrency (4) and cap the per-controller
+          # apiserver request rate to bound etcd load on workload clusters.
           - target:
               kind: Deployment
               name: "(kustomize-controller|helm-controller)"
             patch: |
               - op: add
                 path: /spec/template/spec/containers/0/args/-
-                value: --concurrent=42
+                value: --concurrent=4
+              - op: add
+                path: /spec/template/spec/containers/0/args/-
+                value: --kube-api-qps=50
+              - op: add
+                path: /spec/template/spec/containers/0/args/-
+                value: --kube-api-burst=100
       sync:
         kind: GitRepository
         url: "https://github.com/RPCU/argus.git"


### PR DESCRIPTION
Signed-off-by: Victor Hang <vhvictorhang@gmail.com>
