### PR TITLE
fix 🐛 (chihiro): point generated Cluster template to openstack-kamaji-v1 legacy ClusterClass

### DIFF
--- a/clusters/mgmt/apps/chihiro/cm.yaml
+++ b/clusters/mgmt/apps/chihiro/cm.yaml
@@ -103,7 +103,7 @@ data:
                 - {{ chihiro.serviceCIDR }}
           topology:
             classRef:
-              name: openstack-kamaji
+              name: openstack-kamaji-v1
             controlPlane:
               replicas: 0
             variables:


### PR DESCRIPTION
Signed-off-by: Victor Hang <vhvictorhang@gmail.com>
