### PR TITLE
feat ✨ (sveltos): add gateway-api/kgateway ClusterProfile for workload clusters and fix external-dns template to read app-cred ID from status.atProvider.id

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -251,7 +251,7 @@ _trust-manager/configs/_ - Trust bundle configuration
   - `helmrelease-crds.yaml` - kgateway CRDs Helm chart
   - `kustomization.yaml` - Kustomization manifest
 - `helmrelease.yaml` - kgateway controller Helm chart
-- `gateway.yaml` - `Gateway` resource definition
+- `gateway.yaml` - `Gateway` resource definition (openstack cluster)
 - `httplistenerpolicy.yaml` - `HTTPListenerPolicy` for WebSocket upgrades and access logs
 - `kustomization.yaml` - Kustomization manifest
 
@@ -845,6 +845,35 @@ flux-instance` (it pushes a Flux Kustomization CR + HelmRelease reconciled by
     (`infrastructure/yaook/designate.yaml`) which OR-s `role:dns_manager` into
     the recordset CRUD + zone-read targets.
 
+- `clusterprofiles/gateway-api.yaml` - **Per-child-cluster Gateway API + kgateway
+  add-on**. Gives each OPT-IN workload cluster the Gateway API CRDs, the kgateway
+  controller, and a workload-cluster Gateway for TLS-terminated HTTP/HTTPS
+  ingress. Delivered as a Flux takeover (same pattern as
+  openstack-ccm/openstack-cinder-csi/external-dns). Three Flux Kustomization CRs
+  are pushed: **(1)** `gateway-api` — upstream Gateway API experimental CRDs
+  (`./infrastructure/gateway-api`); **(2)** `kgateway-crds` — kgateway CRDs
+  (`./infrastructure/kgateway/crds`, dependsOn gateway-api); **(3)** `kgateway` —
+  kgateway controller (`./infrastructure/kgateway`, dependsOn kgateway-crds),
+  patched to replace the base's resources list with only `helmrelease.yaml` (strips
+  the openstack-specific `gateway.yaml` and `httplistenerpolicy.yaml` from the
+  kustomize build). Additionally, a templated ConfigMap pushes the **Gateway**
+  (hostname `*<cluster>.rpcu.lan`, annotated `cert-manager.io/cluster-issuer:
+vault-issuer`), **GatewayParameters** (LoadBalancer via OpenStack CCM, no Cilium
+  lbipam annotation), **HTTPRoute** (HTTPS redirect), a manually-created
+  **Certificate** (`wildcard-tls` in kgateway-system, SAN `*<cluster>.rpcu.lan`,
+  signed by `vault-issuer`), and **HTTPListenerPolicy** (WebSocket upgrades +
+  access logs) directly to the workload cluster. Sveltos resolves
+  `{{ .Cluster.metadata.name }}` in the hostname/Certificate SAN before pushing.
+  The Certificate is signed by the per-cluster Vault PKI intermediate
+  (`pki-int/sign/cm-<cluster>`); the per-cluster PKI role allows wildcard
+  certificates and subdomains of `<cluster>.rpcu.lan`, so `*<cluster>.rpcu.lan` is
+  accepted. HTTPRoutes attached to this Gateway are synced to Designate by the
+  external-dns add-on (`domainFilters` scoped to `<cluster>.rpcu.lan`). **Opt-in**:
+  `clusterSelector: matchLabels: {type: workload,
+sveltos.argus.rpcu.io/gateway-api: enabled}`; `dependsOn: cert-manager` (the
+  vault-issuer ClusterIssuer must exist before the Gateway is reconciled). Listed
+  in `clusterprofiles/kustomization.yaml`.
+
 - `kustomization.yaml` - Kustomization manifest (namespace, helmrepo, core
   helmrelease, rbac, clusterprofiles/). The main `sveltos/kustomization.yaml`
   references the parent directory files directly; the `core/` subdirectory is
@@ -1407,6 +1436,13 @@ CAPI management cluster (self-management target via `clusterctl move`):
       cluster it installs cert-manager + the `vault-issuer` ClusterIssuer + the
       `root-mgmt` CA bundle. Improves on flux-mgmt's shared PKI role/AppRole
       (label `sveltos.argus.rpcu.io/cert-manager: enabled`)
+    - `gateway-api` (`syncMode: ContinuousWithDriftDetection`,
+      `dependsOn: cert-manager`) — deploys Gateway API CRDs, kgateway CRDs +
+      controller, and a workload-cluster Gateway (hostname `*<cluster>.rpcu.lan`,
+      `vault-issuer` for TLS). Includes a manually-created wildcard Certificate
+      (`wildcard-tls`) signed by the per-cluster Vault PKI intermediate. HTTPRoutes
+      attached to the Gateway are synced to Designate by the external-dns add-on
+      (label `sveltos.argus.rpcu.io/gateway-api: enabled`)
 
     `wait: false` — the dashboard's placeholder OIDC `clientId` must be set
     before it can come up healthy.
@@ -1885,7 +1921,7 @@ All configuration is declarative, version-controlled, and enables auditable infr
 
 ---
 
-**Last Updated**: July 2026 (Renamed the ExternalDNS add-on to InternalDNS: namespace `external-dns` → `internal-dns`, HelmRelease `external-dns` → `internal-dns`, ServiceAccount `external-dns` → `internal-dns`, ConfigMap generator `external-dns-values` → `internal-dns-values`, RoleBinding `external-dns-capo-variables-reader` → `internal-dns-capo-variables-reader`. The upstream HelmRepository name stays `external-dns` (chart repo). Updated across infrastructure/external-dns/ base, infrastructure/sveltos/clusterprofiles/external-dns.yaml, clusters/mgmt/external-dns.yaml Flux Kustomization name, and AGENTS.md.)
+**Last Updated**: July 2026 (Fixed external-dns add-on template: the OpenStack Crossplane provider does NOT write `attribute.id` to the connection secret — only `attribute.secret`. Added a second `templateResourceRefs` entry (`DnsAppCred`) for the `ApplicationCredentialV3` resource itself, reading the app-cred ID from `status.atProvider.id`. Added gateway-api/kgateway Sveltos add-on for workload clusters: `infrastructure/sveltos/clusterprofiles/gateway-api.yaml` ClusterProfile. Flux takeover pattern: pushes Gateway API CRDs, kgateway CRDs + controller as Flux Kustomization CRs. The kgateway Flux Kustomization patches the base to strip openstack-specific `gateway.yaml` and `httplistenerpolicy.yaml` from the resources list (replaced with only `helmrelease.yaml`). Sveltos-templated ConfigMaps push the Gateway (hostname `*<cluster>.rpcu.lan`, `vault-issuer`), GatewayParameters (OpenStack CCM), a manually-created wildcard Certificate (`wildcard-tls`, SAN `*<cluster>.rpcu.lan`, signed by vault-issuer), HTTPRoute (HTTPS redirect), and HTTPListenerPolicy. Depends on cert-manager add-on for the vault-issuer ClusterIssuer. Renamed the ExternalDNS add-on to InternalDNS: namespace `external-dns` → `internal-dns`, HelmRelease `external-dns` → `internal-dns`, ServiceAccount `external-dns` → `internal-dns`, ConfigMap generator `external-dns-values` → `internal-dns-values`, RoleBinding `external-dns-capo-variables-reader` → `internal-dns-capo-variables-reader`. The upstream HelmRepository name stays `external-dns` (chart repo). Updated across infrastructure/external-dns/ base, infrastructure/sveltos/clusterprofiles/external-dns.yaml, clusters/mgmt/external-dns.yaml Flux Kustomization name, and AGENTS.md.)
 **Repository**: <https://github.com/RPCU/argus.git>
 **Main Branch**: main
 **Clusters**: OpenStack, mgmt (Cluster API management)

--- a/clusters/mgmt/crossplane/openstack/cloud-controller-dns.yaml
+++ b/clusters/mgmt/crossplane/openstack/cloud-controller-dns.yaml
@@ -10,9 +10,9 @@
 # do anything else (no lb, no member, no reader).
 #
 # The connection secret (cloud-controller-app-cred-dns) in crossplane-system
-# contains attribute.id and attribute.secret — the Sveltos external-dns
-# ClusterProfile templates the workload cluster's openstack-credentials from
-# these fields.
+# contains attribute.secret — the Sveltos external-dns ClusterProfile reads the
+# app-cred ID from the ApplicationCredentialV3's status.atProvider.id and the
+# secret from the connection secret.
 # =============================================================================
 apiVersion: identity.openstack.m.crossplane.io/v1alpha1
 kind: RoleV3

--- a/infrastructure/sveltos/clusterprofiles/external-dns.yaml
+++ b/infrastructure/sveltos/clusterprofiles/external-dns.yaml
@@ -34,8 +34,9 @@
 #
 # The admin-project DNS app-cred (cloud-controller-dns) is created by Crossplane
 # in clusters/mgmt/crossplane/openstack/cloud-controller-dns.yaml with only
-# the dns_manager role. Its connection secret (attribute.id + attribute.secret)
-# is read by templateResourceRefs below. The clouds.yaml template hardcodes
+# the dns_manager role. The app-cred ID is read from the Crossplane resource's
+# status.atProvider.id; the secret is in the connection secret
+# (cloud-controller-app-cred-dns). The clouds.yaml template hardcodes
 # auth_url (gateway endpoint, unreachable from workload clusters) and
 # region_name (single-region deployment).
 #
@@ -58,15 +59,22 @@ spec:
       type: workload
       sveltos.argus.rpcu.io/external-dns: enabled
   # Read the admin-project DNS app-cred connection secret from the management
-  # cluster. This contains attribute.id (app-cred ID) and attribute.secret
-  # (app-cred secret), written by Crossplane's ApplicationCredentialV3
-  # (cloud-controller-dns in crossplane-system).
+  # cluster (contains attribute.secret — the app-cred secret). The OpenStack
+  # Crossplane provider does NOT write attribute.id to the connection secret;
+  # the app-cred ID is in the ApplicationCredentialV3's status.atProvider.id,
+  # so we also register the resource itself.
   templateResourceRefs:
     - resource:
         apiVersion: v1
         kind: Secret
         namespace: crossplane-system
         name: cloud-controller-app-cred-dns
+      identifier: DnsAppCredSecret
+    - resource:
+        apiVersion: identity.openstack.m.crossplane.io/v1alpha1
+        kind: ApplicationCredentialV3
+        namespace: crossplane-system
+        name: cloud-controller-dns
       identifier: DnsAppCred
   policyRefs:
     - name: internal-dns-credentials
@@ -81,9 +89,10 @@ spec:
 ---
 # Shared admin-project DNS credentials, generated DYNAMICALLY. Sveltos
 # instantiates this template on the management cluster:
-#   - DnsAppCred: the admin-project DNS app-cred connection secret from
-#                  crossplane-system. The template extracts attribute.id
-#                  (app-cred ID) and attribute.secret (app-cred secret).
+#   - DnsAppCredSecret: the app-cred connection secret from crossplane-system
+#                        (contains attribute.secret).
+#   - DnsAppCred: the ApplicationCredentialV3 resource itself
+#                  (status.atProvider.id has the app-cred ID).
 #
 # It deploys an Opaque Secret openstack-credentials into the workload cluster's
 # internal-dns namespace with a single clouds.yaml key under the cloud name
@@ -101,9 +110,10 @@ metadata:
     projectsveltos.io/template: "true"
 data:
   internal-dns-credentials.yaml: |
+    {{- $appCredSecret := getResource "DnsAppCredSecret" }}
     {{- $appCred := getResource "DnsAppCred" }}
-    {{- $appCredId := $appCred.data.attribute.id | b64dec }}
-    {{- $appCredSecret := $appCred.data.attribute.secret | b64dec }}
+    {{- $appCredId := $appCred.status.atProvider.id }}
+    {{- $appCredSecretVal := $appCredSecret.data.attribute.secret | b64dec }}
     apiVersion: v1
     kind: Secret
     metadata:
@@ -117,7 +127,7 @@ data:
             auth:
               auth_url: https://keystone.rpcu.vpn
               application_credential_id: "{{ $appCredId }}"
-              application_credential_secret: "{{ $appCredSecret }}"
+              application_credential_secret: "{{ $appCredSecretVal }}"
             region_name: eu-central
             verify: false
             interface: public

--- a/infrastructure/sveltos/clusterprofiles/gateway-api.yaml
+++ b/infrastructure/sveltos/clusterprofiles/gateway-api.yaml
@@ -1,0 +1,258 @@
+# Gateway API + kgateway for OPT-IN workload clusters, delivered as a Flux
+# takeover (same pattern as openstack-ccm/openstack-cinder-csi/external-dns).
+#
+# Deploys:
+#   1. Gateway API CRDs (upstream experimental channel)
+#   2. kgateway CRDs + controller
+#   3. A workload-cluster Gateway (*.cluster.rpcu.lan) using the vault-issuer
+#      ClusterIssuer from the cert-manager add-on for TLS
+#
+# A manually-created Certificate (wildcard-tls) in kgateway-system is signed
+# by the vault-issuer (pki-int/sign/cm-<cluster>). The per-cluster PKI role
+# allows wildcard certificates and subdomains of <cluster>.rpcu.lan, so
+# *.<cluster>.rpcu.lan is accepted. The Gateway references this Certificate's
+# TLS secret for termination.
+#
+# HTTPRoutes attached to this Gateway are synced to Designate by the external-dns
+# add-on (domainFilters scoped to <cluster>.rpcu.lan).
+#
+# Gated by the opt-in label sveltos.argus.rpcu.io/gateway-api: enabled.
+#
+# dependsOn the cert-manager ClusterProfile: the vault-issuer ClusterIssuer must
+# exist before the Gateway can be reconciled (the cert-manager.io/cluster-issuer
+# annotation references it).
+apiVersion: config.projectsveltos.io/v1beta1
+kind: ClusterProfile
+metadata:
+  name: gateway-api
+  namespace: projectsveltos
+spec:
+  syncMode: ContinuousWithDriftDetection
+  dependsOn:
+    - cert-manager
+  clusterSelector:
+    matchLabels:
+      type: workload
+      sveltos.argus.rpcu.io/gateway-api: enabled
+  policyRefs:
+    - name: gateway-api-flux-kustomizations
+      namespace: projectsveltos
+      kind: ConfigMap
+    - name: gateway-api-workload-resources
+      namespace: projectsveltos
+      kind: ConfigMap
+---
+# Flux Kustomization CRs for the Gateway API CRDs, kgateway CRDs, and
+# kgateway controller. Deployed as raw manifests (not templated) because
+# they don't need per-cluster values.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: gateway-api-flux-kustomizations
+  namespace: projectsveltos
+data:
+  gateway-api-crds.yaml: |
+    apiVersion: kustomize.toolkit.fluxcd.io/v1
+    kind: Kustomization
+    metadata:
+      name: gateway-api
+      namespace: flux-system
+    spec:
+      interval: 10m
+      sourceRef:
+        kind: GitRepository
+        name: flux-system
+        namespace: flux-system
+      path: ./infrastructure/gateway-api
+      prune: false
+      wait: true
+      timeout: 5m
+  kgateway-crds.yaml: |
+    apiVersion: kustomize.toolkit.fluxcd.io/v1
+    kind: Kustomization
+    metadata:
+      name: kgateway-crds
+      namespace: flux-system
+    spec:
+      interval: 10m
+      dependsOn:
+        - name: gateway-api
+      sourceRef:
+        kind: GitRepository
+        name: flux-system
+        namespace: flux-system
+      path: ./infrastructure/kgateway/crds
+      prune: false
+      wait: true
+      timeout: 5m
+  kgateway.yaml: |
+    apiVersion: kustomize.toolkit.fluxcd.io/v1
+    kind: Kustomization
+    metadata:
+      name: kgateway
+      namespace: flux-system
+    spec:
+      interval: 10m
+      dependsOn:
+        - name: kgateway-crds
+      sourceRef:
+        kind: GitRepository
+        name: flux-system
+        namespace: flux-system
+      path: ./infrastructure/kgateway
+      prune: false
+      patches:
+        # Strip the openstack-specific Gateway + HTTPListenerPolicy from the base
+        # kustomization — workload clusters get these from the templated ConfigMap
+        # pushed by this ClusterProfile (hostname *<cluster>.rpcu.lan, vault-issuer,
+        # no Cilium lbipam annotation). Replace the resources list with only
+        # helmrelease.yaml so kustomize build skips gateway.yaml and
+        # httplistenerpolicy.yaml.
+        - patch: |
+            apiVersion: kustomize.toolkit.fluxcd.io/v1
+            kind: Kustomization
+            metadata:
+              name: kgateway
+            spec:
+              resources:
+                - helmrelease.yaml
+          target:
+            kind: Kustomization
+            name: kgateway
+---
+# Gateway + Certificate + HTTPListenerPolicy for the workload cluster. The
+# Gateway hostname is templated with the cluster name (*.cluster.rpcu.lan).
+# Sveltos resolves {{ .Cluster.metadata.name }} before pushing to the workload
+# cluster. A manually-created Certificate (wildcard-tls) is signed by the
+# vault-issuer; the Gateway references its TLS secret.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: gateway-api-workload-resources
+  namespace: projectsveltos
+  annotations:
+    projectsveltos.io/template: "true"
+data:
+  gateway.yaml: |
+    apiVersion: gateway.networking.k8s.io/v1
+    kind: Gateway
+    metadata:
+      name: https
+      namespace: kgateway-system
+      annotations:
+        cert-manager.io/cluster-issuer: vault-issuer
+        kgateway.dev/per-connection-buffer-limit: "128Mi"
+    spec:
+      gatewayClassName: kgateway
+      allowedListeners:
+        namespaces:
+          from: All
+      infrastructure:
+        parametersRef:
+          group: gateway.kgateway.dev
+          kind: GatewayParameters
+          name: gwp-static-ip
+      listeners:
+        - protocol: HTTP
+          port: 80
+          name: http
+          hostname: "*{{ .Cluster.metadata.name }}.rpcu.lan"
+          allowedRoutes:
+            namespaces:
+              from: All
+        - protocol: HTTPS
+          port: 443
+          name: https
+          hostname: "*{{ .Cluster.metadata.name }}.rpcu.lan"
+          allowedRoutes:
+            namespaces:
+              from: All
+          tls:
+            mode: Terminate
+            certificateRefs:
+              - name: wildcard-tls
+    ---
+    apiVersion: gateway.kgateway.dev/v1alpha1
+    kind: GatewayParameters
+    metadata:
+      name: gwp-static-ip
+      namespace: kgateway-system
+    spec:
+      kube:
+        envoyContainer:
+          resources:
+            limits:
+              memory: 4Gi
+            requests:
+              memory: 1Gi
+        service:
+          type: LoadBalancer
+    ---
+    apiVersion: gateway.networking.k8s.io/v1
+    kind: HTTPRoute
+    metadata:
+      name: https-redirect
+      namespace: kgateway-system
+    spec:
+      parentRefs:
+        - name: https
+          sectionName: http
+          namespace: kgateway-system
+      rules:
+        - filters:
+            - type: RequestRedirect
+              requestRedirect:
+                scheme: https
+                statusCode: 301
+  certificate.yaml: |
+    # Wildcard certificate for the workload cluster's Gateway. Signed by the
+    # vault-issuer (pki-int/sign/cm-<cluster>). The SAN is
+    # *.<cluster>.rpcu.lan which matches the Gateway's listener hostname.
+    # cert-manager renews at 2/3 of the 90-day lifetime.
+    apiVersion: cert-manager.io/v1
+    kind: Certificate
+    metadata:
+      name: wildcard-tls
+      namespace: kgateway-system
+    spec:
+      secretName: wildcard-tls
+      issuerRef:
+        name: vault-issuer
+        kind: ClusterIssuer
+        group: cert-manager.io
+      dnsNames:
+        - "*{{ .Cluster.metadata.name }}.rpcu.lan"
+  httplistenerpolicy.yaml: |
+    apiVersion: gateway.kgateway.dev/v1alpha1
+    kind: HTTPListenerPolicy
+    metadata:
+      name: upgrades
+      namespace: kgateway-system
+    spec:
+      targetRefs:
+        - group: gateway.networking.k8s.io
+          kind: Gateway
+          name: https
+      upgradeConfig:
+        enabledUpgrades:
+          - "websocket"
+      accessLog:
+        - fileSink:
+            path: /dev/stdout
+            jsonFormat:
+              start_time: "%START_TIME%"
+              method: "%REQ(X-ENVOY-ORIGINAL-METHOD?:METHOD)%"
+              path: "%REQ(X-ENVOY-ORIGINAL-PATH?:PATH)%"
+              protocol: "%PROTOCOL%"
+              response_code: "%RESPONSE_CODE%"
+              response_flags: "%RESPONSE_FLAGS%"
+              bytes_received: "%BYTES_RECEIVED%"
+              bytes_sent: "%BYTES_SENT%"
+              total_duration: "%DURATION%"
+              resp_backend_service_time: "%RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)%"
+              req_x_forwarded_for: "%REQ(X-FORWARDED-FOR)%"
+              user_agent: "%REQ(USER-AGENT)%"
+              request_id: "%REQ(X-REQUEST-ID)%"
+              authority: "%REQ(:AUTHORITY)%"
+              backendHost: "%UPSTREAM_HOST%"
+              backendCluster: "%UPSTREAM_CLUSTER%"

--- a/infrastructure/sveltos/clusterprofiles/kustomization.yaml
+++ b/infrastructure/sveltos/clusterprofiles/kustomization.yaml
@@ -9,3 +9,4 @@ resources:
   - vault-auth.yaml
   - cert-manager.yaml
   - external-dns.yaml
+  - gateway-api.yaml


### PR DESCRIPTION
Signed-off-by: Victor Hang <vhvictorhang@gmail.com>
