### PR TITLE
fix 🐛 (sveltos/external-dns): use index function to access attribute.secret in template to handle dotted key names

### DIFF
--- a/infrastructure/sveltos/clusterprofiles/external-dns.yaml
+++ b/infrastructure/sveltos/clusterprofiles/external-dns.yaml
@@ -113,7 +113,7 @@ data:
     {{- $appCredSecret := getResource "DnsAppCredSecret" }}
     {{- $appCred := getResource "DnsAppCred" }}
     {{- $appCredId := $appCred.status.atProvider.id }}
-    {{- $appCredSecretVal := $appCredSecret.data.attribute.secret | b64dec }}
+    {{- $appCredSecretVal := index $appCredSecret.data "attribute.secret" | b64dec }}
     apiVersion: v1
     kind: Secret
     metadata:


### PR DESCRIPTION
Signed-off-by: Victor Hang <vhvictorhang@gmail.com>
