### PR TITLE
refactor 🎨 (rook): replace deprecated spec.loadBalancerIP with Cilium lbipam annotation on NFS service

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -283,12 +283,17 @@ _rook/configs/_ - Ceph cluster configuration
 - `cephnfs.yaml` - `CephNFS` gateway `rpcu-nfs` (1 active NFS-Ganesha server)
   exporting the `rpcu-fs` CephFilesystem to EXTERNAL clusters, + a
   `LoadBalancer` Service pinned at `10.0.0.245` (Cilium L2 pool) on TCP/2049.
-  This exists because the Rook cluster is POD-networked: mons advertise
-  ClusterIPs and mgr/MDS/OSDs advertise pod IPs in the Ceph maps, so an
-  external ceph-csi client can NEVER reach them (CreateVolume hangs → PVCs
-  Pending forever) — LB-fronted mons are not sufficient. The NFS gateway runs
-  in-cluster; consumers only need TCP/2049. The export itself is created ONCE
-  out of band (persisted in the `.nfs` RADOS pool):
+  The IP is pinned via the `lbipam.cilium.io/ips` annotation (repo convention,
+  same as `infrastructure/kgateway/gateway.yaml`) — NOT the deprecated
+  `spec.loadBalancerIP` field. This exists because the Rook cluster is
+  POD-networked: mons advertise ClusterIPs and mgr/MDS/OSDs advertise pod IPs
+  in the Ceph maps, so an external ceph-csi client can NEVER reach them
+  (CreateVolume hangs → PVCs Pending forever) — LB-fronted mons are not
+  sufficient. (The out-of-band `rook-ceph-mon-{a,d,f}-external` LB Services at
+  `10.0.0.242-244` from that failed attempt were deleted from the live
+  cluster; `.242-.244` are free again.) The NFS gateway runs in-cluster;
+  consumers only need TCP/2049. The export itself is created ONCE out of band
+  (persisted in the `.nfs` RADOS pool):
   `ceph nfs export create cephfs rpcu-nfs /rpcu-fs rpcu-fs --path=/`.
 - `openstack-clients.yaml` - CephClients: `glance` + `cinder` (rbd caps).
   (The former external `cephfs` CephClient was removed together with the

--- a/infrastructure/rook/configs/cephnfs.yaml
+++ b/infrastructure/rook/configs/cephnfs.yaml
@@ -35,7 +35,9 @@ spec:
 # is what the consuming clusters' `ceph-cephfs` StorageClass points at
 # (infrastructure/csi-driver-nfs/storageclass.yaml `server:` parameter — keep
 # the two in sync). Rook's own ClusterIP service remains for intra-cluster
-# use; this one is additive.
+# use; this one is additive. The IP is pinned via the Cilium LB-IPAM
+# annotation (same convention as infrastructure/kgateway/gateway.yaml) —
+# spec.loadBalancerIP is deprecated since Kubernetes v1.24.
 apiVersion: v1
 kind: Service
 metadata:
@@ -44,9 +46,10 @@ metadata:
   labels:
     app: rook-ceph-nfs
     ceph_nfs: rpcu-nfs
+  annotations:
+    lbipam.cilium.io/ips: "10.0.0.245"
 spec:
   type: LoadBalancer
-  loadBalancerIP: 10.0.0.245
   selector:
     app: rook-ceph-nfs
     ceph_nfs: rpcu-nfs


### PR DESCRIPTION
Signed-off-by: Victor Hang <vhvictorhang@gmail.com>
