### PR TITLE
fix 🐛 (yaook/nova): disk_cachemodes must be a list

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -444,6 +444,11 @@ TCP/2049 to the LB IP — no Ceph credentials, no Vault/ESO plumbing.
 - `values.yaml` - Custom Helm values
 - `kustomization.yaml` - Kustomization manifest
 
+**golinky/** - Link Shortener (v0.3.1)
+
+- `kustomization.yaml` - Kustomization manifest (namespace: golinky, upstream bundle from `didactiklabs/golinky` v0.3.1)
+- `golinky-service-patch.yaml` - Strategic merge patch: `type: LoadBalancer` with `lbipam.cilium.io/ips: "10.0.0.241"` for Cilium L2 IP pinning
+
 **openstack-ccm/** - OpenStack Cloud Controller Manager (chart v2.35.0, app v1.35.0)
 
 Provides `Service` type `LoadBalancer` via OpenStack Octavia and initialises
@@ -2126,7 +2131,7 @@ All configuration is declarative, version-controlled, and enables auditable infr
 
 ---
 
-**Last Updated**: July 2026 (Fixed EC profile crush-device-class for ObjectStore, raised mon_max_pg_per_osd to 400, added rook-ceph-config ConfigMap)
+**Last Updated**: July 2026 (Added golinky link shortener to openstack cluster, fixed EC profile crush-device-class for ObjectStore, raised mon_max_pg_per_osd to 400, added rook-ceph-config ConfigMap)
 **Repository**: <https://github.com/RPCU/argus.git>
 **Main Branch**: main
 **Clusters**: OpenStack, mgmt (Cluster API management)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1208,9 +1208,22 @@ reconciled by the operators above. Deployed by the `yaook` Flux Kustomization
   glance/cinder share one Ceph cluster).
 - `neutron.yaml` - NeutronDeployment (networking)
 - `nova.yaml` - NovaDeployment (compute). libvirt I/O tuning for RBD-backed
-  disks: `disk_cachemodes: network=writeback` (librbd writeback cache —
+  disks: `disk_cachemodes: [network=writeback]` (librbd writeback cache —
   flushed on guest fsync, large guest write-latency win) and
   `hw_disk_discard: unmap` (guest TRIM reclaims space in the Ceph pool).
+  **`disk_cachemodes` MUST be a LIST** (`[network=writeback]`), not a bare
+  string. The yaook operator 2.4.0 CUE schema
+  (`nova_template/openstack_default_nova.cue`: `"disk_cachemodes"?: [...string]`)
+  rejects a scalar string with `conflicting values "network=writeback" and
+[...string]` → the generated `NovaComputeNode` goes `ConfigurationInvalid`.
+  A scalar here is worse than a plain config error: because it makes the
+  rendered compute config "not up-to-date", the nova-operator flags every node
+  `RequiresRecreation=True` and starts a **rolling recreate** (maxUnavailable=1)
+  that DELETEs each `NovaComputeNode` and evicts (live-migrates) its VMs before
+  recreating it. If live-migration cannot converge on this cluster, each node
+  wedges mid-eviction (`state: Evicting`, `phase: WaitingForDependency`) with
+  its compute service left `disabled` — cascading across lucy/makise/quinn one
+  at a time. (Pre-2.4.0 the scalar was tolerated; the upgrade tightened it.)
 - `cinder.yaml` - CinderDeployment (block storage, rook-ceph RBD backend)
 - `horizon.yaml` - HorizonDeployment (dashboard)
 - `octavia.yaml` - OctaviaDeployment (load balancing)
@@ -2131,7 +2144,7 @@ All configuration is declarative, version-controlled, and enables auditable infr
 
 ---
 
-**Last Updated**: July 2026 (Added golinky link shortener to openstack cluster, fixed EC profile crush-device-class for ObjectStore, raised mon_max_pg_per_osd to 400, added rook-ceph-config ConfigMap)
+**Last Updated**: July 2026 (Fixed nova.yaml disk_cachemodes to list form — yaook operator 2.4.0 CUE schema requires `[...string]`; a scalar string triggered a cluster-wide NovaComputeNode rolling recreate that wedged nodes in Evicting because live-migration cannot converge)
 **Repository**: <https://github.com/RPCU/argus.git>
 **Main Branch**: main
 **Clusters**: OpenStack, mgmt (Cluster API management)

--- a/clusters/openstack/golinky.yaml
+++ b/clusters/openstack/golinky.yaml
@@ -1,0 +1,15 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: golinky
+  namespace: flux-system
+spec:
+  interval: 10m0s
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  path: ./infrastructure/golinky
+  prune: true
+  wait: true
+  timeout: 5m

--- a/clusters/openstack/kustomization.yaml
+++ b/clusters/openstack/kustomization.yaml
@@ -10,5 +10,6 @@ resources:
   - external-secrets.yaml
   - flux-operator.yaml
   - rook.yaml
+  - golinky.yaml
   - yaook-operator.yaml
   - fluxcd/

--- a/infrastructure/golinky/golinky-service-patch.yaml
+++ b/infrastructure/golinky/golinky-service-patch.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: golinky
+  namespace: golinky
+  annotations:
+    lbipam.cilium.io/ips: "10.0.0.242"
+spec:
+  type: LoadBalancer

--- a/infrastructure/golinky/kustomization.yaml
+++ b/infrastructure/golinky/kustomization.yaml
@@ -1,0 +1,5 @@
+namespace: golinky
+resources:
+  - https://github.com/didactiklabs/golinky/releases/download/v0.3.1/bundle.yaml
+patches:
+  - path: golinky-service-patch.yaml

--- a/infrastructure/yaook/nova.yaml
+++ b/infrastructure/yaook/nova.yaml
@@ -45,7 +45,8 @@ spec:
             # librbd writeback cache for network (RBD) disks — large guest
             # write-latency improvement; safe with virtio: the cache is
             # flushed on guest fsync/barrier requests.
-            disk_cachemodes: network=writeback
+            disk_cachemodes:
+              - network=writeback
             # Pass guest TRIM/discard through to Ceph so deleted blocks are
             # reclaimed in the pool (needs virtio-scsi or virtio-blk w/ recent
             # machine types; harmless otherwise).


### PR DESCRIPTION
The scalar string form  in nova.yaml made every regenerated NovaComputeNode go ConfigurationInvalid and flagged all nodes RequiresRecreation, triggering a rolling recreate whose eviction wedges (live-migration never converges).

- Changed disk_cachemodes from scalar to list form [network=writeback]
- Updated AGENTS.md documentation for this requirement