### PR TITLE
fix(ci): renovate dry-run mapping + manual schedule bypass

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -53,7 +53,15 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
         env:
           RENOVATE_REPOSITORIES: ${{ github.repository }}
-          RENOVATE_DRY_RUN: ${{ github.event.inputs.dryRun || 'disabled' }}
+          # RENOVATE_DRY_RUN only accepts null/extract/lookup/full. The
+          # workflow input's "disabled" choice must map to an EMPTY value
+          # (a real run) — passing the literal "disabled" is treated as
+          # truthy and forces dry-run. Only forward the real dry-run modes.
+          RENOVATE_DRY_RUN: ${{ (github.event.inputs.dryRun == 'full' || github.event.inputs.dryRun == 'extract') && github.event.inputs.dryRun || '' }}
+          # A MANUAL (workflow_dispatch) run bypasses the `schedule` in
+          # renovate.json5 so you can force PRs on demand; scheduled cron runs
+          # still respect the Monday-morning window.
+          RENOVATE_FORCE: ${{ github.event_name == 'workflow_dispatch' && '{"schedule":null}' || '' }}
           LOG_LEVEL: ${{ github.event.inputs.logLevel || 'info' }}
           # Attribute commits/PRs to the App (self-hosted bot identity).
           RENOVATE_GIT_AUTHOR: "${{ steps.app-token.outputs.app-slug }}[bot] <${{ steps.app-token.outputs.app-slug }}@users.noreply.github.com>"


### PR DESCRIPTION
Follow-up to #349. Two fixes so real update PRs actually get created:

1. `RENOVATE_DRY_RUN` only accepts `null`/`extract`/`lookup`/`full`. The dispatch input's `disabled` choice was forwarded literally and treated as truthy, forcing **every** run (including `dryRun=disabled`) into dry-run. Now `disabled` maps to an empty value.
2. `RENOVATE_FORCE={"schedule":null}` is set on `workflow_dispatch` so a **manual** run bypasses the Monday-morning `schedule` window in `renovate.json5` and opens PRs on demand; scheduled cron runs still respect the window.