### PR TITLE
fix(renovate): drop npins manager, silence provider-random, pin ceph images

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1807,11 +1807,16 @@ argus alongside the self-hosted job, exclude argus from that App's access
   6. **Helm-values `tag:` without a sibling `repository:`** — inline marker in
      `infrastructure/kamaji/values.yaml` (`docker.io/clastix/kamaji`).
   7. **Plain `image: registry/repo:tag`** in raw manifests → `docker` (rook
-     ceph image + toolbox, chihiro).
-  8. **npins** GitRelease pin in `npins/sources.json` → `github-releases`
-     (sveltosctl). Note: bumping the JSON pin alone is not sufficient — the
-     `hash`/`revision` must be refreshed with `npins update`; treat such PRs as a
-     signal to run `npins update` locally.
+     ceph image + toolbox + nfs-export CronJob, chihiro). All three
+     `quay.io/ceph/ceph` images are pinned to the same full tag (`v19.2.3`,
+     not a floating `v19`) and grouped so they bump in lockstep.
+
+**npins is NOT managed by Renovate.** `npins/sources.json` pins carry a
+`revision`/`url`/`hash` that a Renovate regex cannot refresh (it could only bump
+the `version` string, leaving a stale hash that breaks the Nix build). The
+dedicated `.github/workflows/npins-update.yaml` workflow runs `npins update`
+across ALL pins every 6h and opens correct PRs with refreshed hashes — it is the
+sole owner of npins updates (sveltosctl, nixpkgs, etc.).
 
 **Grouping (packageRules):** yaook operators (shared 2.2.0), openstack
 cloud-provider (CCM + Cinder CSI + their images), cluster-api providers, cilium

--- a/infrastructure/rook/configs/nfs-export-ensure.yaml
+++ b/infrastructure/rook/configs/nfs-export-ensure.yaml
@@ -46,7 +46,7 @@ spec:
           serviceAccountName: rook-ceph-default
           containers:
             - name: export-ensure
-              image: quay.io/ceph/ceph:v19
+              image: quay.io/ceph/ceph:v19.2.3
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/bash

--- a/infrastructure/rook/configs/toolbox-deployment.yaml
+++ b/infrastructure/rook/configs/toolbox-deployment.yaml
@@ -19,7 +19,7 @@ spec:
       serviceAccountName: rook-ceph-default
       containers:
         - name: rook-ceph-tools
-          image: quay.io/ceph/ceph:v19
+          image: quay.io/ceph/ceph:v19.2.3
           command:
             - /bin/bash
             - -c

--- a/renovate.json5
+++ b/renovate.json5
@@ -4,15 +4,20 @@
 //   - Reliably update Flux HelmReleases (HTTP + OCI repos), container images
 //     (incl. those buried in Helm `values.yaml` blocks), Kustomize remote
 //     bases pinned to GitHub release URLs / `?ref=` tags, Crossplane provider
-//     & function packages, Cluster API provider version fields, the Sveltos
-//     ClusterProfile inline `helmCharts`, and the npins Go-release pin.
+//     & function packages, Cluster API provider version fields, and the Sveltos
+//     ClusterProfile inline `helmCharts`.
 //   - Manual review for everything (no auto-merge) — production GitOps.
 //
 // Most work is done by Renovate's built-in `flux` and `helm-values` managers.
 // The `customManagers` (regex) below cover the version pins that no built-in
 // manager understands (URL-pinned kustomize bases, Crossplane packages, CAPI
-// provider `version:` fields, Sveltos inline charts, the npins pin, and a few
-// image tags expressed in non-standard YAML shapes).
+// provider `version:` fields, Sveltos inline charts, and a few image tags
+// expressed in non-standard YAML shapes).
+//
+// npins pins (npins/sources.json) are deliberately left to the dedicated
+// `.github/workflows/npins-update.yaml` workflow, which runs `npins update`
+// and refreshes the pin hash — a Renovate regex could only bump the version
+// string and would leave a stale hash that breaks the Nix build.
 {
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
 
@@ -157,17 +162,12 @@
       datasourceTemplate: "docker",
     },
 
-    // 8. npins GitRelease pin (npins/sources.json). Tracks the Go release tag.
-    {
-      customType: "regex",
-      managerFilePatterns: ["/(^|/)npins/sources\\.json$/"],
-      matchStrings: [
-        '"owner":\\s*"(?<owner>[^"]+)",\\s*"repo":\\s*"(?<repo>[^"]+)"[\\s\\S]*?"version":\\s*"(?<currentValue>v?[0-9][^"]+)"',
-      ],
-      depNameTemplate: "{{{owner}}}/{{{repo}}}",
-      datasourceTemplate: "github-releases",
-      versioningTemplate: "semver",
-    },
+    // NOTE: npins pins (npins/sources.json) are intentionally NOT managed by
+    // Renovate. A regex manager can only bump the `version` field, leaving the
+    // pin's `revision`/`url`/`hash` stale — which breaks the Nix build. The
+    // repo's dedicated `.github/workflows/npins-update.yaml` runs `npins update`
+    // across ALL pins every 6h and opens correct PRs with refreshed hashes, so
+    // it is the sole owner of npins updates (sveltosctl, nixpkgs, etc.).
   ],
 
   // ---------------------------------------------------------------------------
@@ -180,6 +180,13 @@
       matchManagers: ["flux"],
       matchPackageNames: ["/-operator$/", "/^crds$/"],
       matchFileNames: ["infrastructure/yaook-operator/**"],
+    },
+
+    // Group all Ceph daemon images (cephcluster + toolbox + nfs-export CronJob)
+    // so they bump in lockstep — they must stay on the same Ceph release.
+    {
+      groupName: "ceph image",
+      matchPackageNames: ["quay.io/ceph/ceph"],
     },
 
     // Group the OpenStack cloud-provider charts + their images (CCM + Cinder
@@ -231,6 +238,20 @@
     {
       matchPackageNames: ["kamaji", "kamaji-crds"],
       matchManagers: ["flux"],
+      enabled: false,
+    },
+
+    // provider-random (crossplane-contrib) is unused AND no longer resolvable
+    // on any registry (crossplane-contrib moved off xpkg.upbound.io; the
+    // package returns no-result on upbound and ghcr alike), so Renovate logs a
+    // persistent "Failed to look up docker package ... no-result" warning.
+    // It's already flagged in AGENTS.md as unused / failing to install /
+    // candidate for removal. Disable lookups for it to silence the warning.
+    {
+      matchPackageNames: [
+        "xpkg.upbound.io/crossplane-contrib/provider-random",
+        "/crossplane-contrib/provider-random$/",
+      ],
       enabled: false,
     },
 


### PR DESCRIPTION
Follow-ups from the Renovate rollout.

- **npins**: removed Renovate's npins custom manager. A regex can only bump the `version` in `npins/sources.json` and leaves `revision`/`url`/`hash` stale, breaking the Nix build. The existing `.github/workflows/npins-update.yaml` already runs `npins update` across all pins every 6h with correct hashes, so it owns npins updates (incl. sveltosctl).
- **provider-random**: the last run's only lookup failure. `crossplane-contrib/provider-random` is unused and unresolvable on every registry (no-result on upbound and ghcr). Added a packageRule disabling lookups to silence the warning (kept in place per request).
- **ceph images**: pinned the rook toolbox + nfs-export CronJob images from floating `v19` to full `v19.2.3` (matching `cephcluster.yaml`) and grouped all `quay.io/ceph/ceph` images so they bump in lockstep.

Changelogs already work — Renovate fetches full release notes into PR bodies via the `github-releases`/`docker` datasources (see #360).