### PR TITLE
feat: yaook-releases workflow + rsync cold-migration fix

### DIFF
--- a/.github/workflows/yaook-releases.yaml
+++ b/.github/workflows/yaook-releases.yaml
@@ -1,0 +1,150 @@
+name: yaook openstack releases
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 3 * * 1" # Monday 03:00 UTC
+permissions:
+  contents: "write"
+  pull-requests: "write"
+jobs:
+  check-releases:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Fetch latest yaook operator releases
+        id: fetch
+        run: |
+          # Fetch the latest default branch HEAD
+          YAOOK_DEFAULT=$(curl -s "https://gitlab.com/api/v4/projects/yaook%2Foperator/repository/branches/main" | jq -r '.commit.id')
+          echo "yaook_commit=$YAOOK_DEFAULT" >> "$GITHUB_OUTPUT"
+
+          # Components and their source file paths in the yaook repo.
+          # Each component's __init__.py (or cr.py for nova) contains a
+          # RELEASES = [...] list that defines the supported OpenStack releases.
+          declare -A COMPONENT_FILES=(
+            [keystone]="yaook/op/keystone/cr.py"
+            [nova]="yaook/op/nova/cr.py"
+            [glance]="yaook/op/glance/__init__.py"
+            [neutron]="yaook/op/neutron/__init__.py"
+            [cinder]="yaook/op/cinder/__init__.py"
+            [horizon]="yaook/op/horizon/__init__.py"
+            [octavia]="yaook/op/octavia/__init__.py"
+            [designate]="yaook/op/designate/__init__.py"
+          )
+
+          # Collect all unique releases across all components
+          ALL_RELEASES=""
+
+          for component in "${!COMPONENT_FILES[@]}"; do
+            file_path="${COMPONENT_FILES[$component]}"
+            encoded_path=$(python3 -c "import urllib.parse; print(urllib.parse.quote('$file_path', safe=''))")
+
+            content=$(curl -s "https://gitlab.com/api/v4/projects/yaook%2Foperator/repository/files/${encoded_path}/raw?ref=${YAOOK_DEFAULT}")
+
+            # Extract the RELEASES list from the Python source.
+            # The list is formatted as:
+            #   RELEASES = [
+            #       "2025.1",
+            #       "2026.1",
+            #   ]
+            # We extract everything between RELEASES = [ and the closing ],
+            releases=$(echo "$content" | python3 -c "
+          import sys, re
+          text = sys.stdin.read()
+          m = re.search(r'RELEASES\s*=\s*\[(.*?)\]', text, re.DOTALL)
+          if m:
+              for line in m.group(1).splitlines():
+                  line = line.strip().strip(',').strip('\"').strip(\"'\")
+                  if re.match(r'^\d{4}\.\d+$', line):
+                      print(line)
+          ")
+
+            echo "Component $component releases: $(echo $releases | tr '\n' ' ')"
+            ALL_RELEASES="$ALL_RELEASES
+          $releases"
+          done
+
+          # Deduplicate and sort
+          UNIQUE_RELEASES=$(echo "$ALL_RELEASES" | sort -u | grep -v '^$')
+          echo "All unique yaook releases:"
+          echo "$UNIQUE_RELEASES"
+          echo "releases<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$UNIQUE_RELEASES" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+
+      - name: Check current targetRelease in CRs
+        id: current
+        run: |
+          # Find all targetRelease values in our yaook CRs
+          CURRENT=$(grep -roh 'targetRelease: "[0-9]\{4\}\.[0-9]*"' infrastructure/yaook/ | grep -o '"[0-9]\{4\}\.[0-9]*"' | tr -d '"' | sort -u)
+          echo "Current targetRelease values:"
+          echo "$CURRENT"
+          echo "current<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$CURRENT" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+
+      - name: Determine upgrade target
+        id: upgrade
+        run: |
+          CURRENT="${{ steps.current.outputs.releases }}"
+          AVAILABLE="${{ steps.fetch.outputs.releases }}"
+
+          # For each current release, find the latest available release
+          # that is >= the current one.
+          LATEST_AVAILABLE=$(echo "$AVAILABLE" | tail -1)
+
+          echo "Current releases: $CURRENT"
+          echo "Latest available: $LATEST_AVAILABLE"
+
+          NEEDS_UPGRADE=false
+
+          while IFS= read -r cur; do
+            [ -z "$cur" ] && continue
+            if [ "$cur" != "$LATEST_AVAILABLE" ]; then
+              echo "Upgrade needed: $cur -> $LATEST_AVAILABLE"
+              NEEDS_UPGRADE=true
+              TARGET="$LATEST_AVAILABLE"
+            fi
+          done <<< "$CURRENT"
+
+          echo "needs_upgrade=$NEEDS_UPGRADE" >> "$GITHUB_OUTPUT"
+          echo "target=$TARGET" >> "$GITHUB_OUTPUT"
+
+      - name: Update targetRelease in CRs
+        if: steps.upgrade.outputs.needs_upgrade == 'true'
+        run: |
+          TARGET="${{ steps.upgrade.outputs.target }}"
+          echo "Updating all yaook CRs to targetRelease: $TARGET"
+
+          # Update targetRelease in all yaook deployment CRs
+          for f in infrastructure/yaook/*.yaml; do
+            if grep -q 'targetRelease:' "$f"; then
+              sed -i "s/targetRelease:.*/targetRelease: \"$TARGET\"/" "$f"
+              echo "Updated $f"
+            fi
+          done
+
+      - name: Create Pull Request
+        if: steps.upgrade.outputs.needs_upgrade == 'true'
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "chore(yaook): upgrade OpenStack release to ${{ steps.upgrade.outputs.target }}"
+          title: "chore(yaook): upgrade OpenStack release to ${{ steps.upgrade.outputs.target }}"
+          body: |
+            Automated upgrade of all yaook OpenStack service deployments to release **${{ steps.upgrade.outputs.target }}**.
+
+            **Source:** [yaook/operator](https://gitlab.com/yaook/operator) commit `${{ steps.fetch.outputs.yaook_commit }}`
+
+            Supported releases per component (from operator source):
+            ```
+            ${{ steps.fetch.outputs.releases }}
+            ```
+
+            This PR updates `targetRelease` in all `infrastructure/yaook/*.yaml` CRs.
+
+            **Before merging:** verify the upgrade path is valid for your deployment. Check the [yaook upgrade documentation](https://yaook.cloud/docs/) for any breaking changes between releases.
+          branch: "yaook-release-upgrade"
+          delete-branch: true

--- a/.github/workflows/yaook-releases.yaml
+++ b/.github/workflows/yaook-releases.yaml
@@ -108,7 +108,7 @@ jobs:
       - name: Determine upgrade target
         id: upgrade
         run: |
-          CURRENT="${{ steps.current.outputs.releases }}"
+          CURRENT="${{ steps.current.outputs.current }}"
           AVAILABLE="${{ steps.fetch.outputs.releases }}"
           LATEST_AVAILABLE=$(echo "$AVAILABLE" | tail -1)
 

--- a/.github/workflows/yaook-releases.yaml
+++ b/.github/workflows/yaook-releases.yaml
@@ -13,16 +13,35 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Fetch latest yaook operator releases
+      - name: Fetch supported releases from yaook operator
         id: fetch
         run: |
-          # Fetch the latest default branch HEAD
-          YAOOK_DEFAULT=$(curl -s "https://gitlab.com/api/v4/projects/yaook%2Foperator/repository/branches/main" | jq -r '.commit.id')
-          echo "yaook_commit=$YAOOK_DEFAULT" >> "$GITHUB_OUTPUT"
+          # 1. Read our current yaook operator chart version from the
+          #    HelmRelease manifests. All operators share the same version.
+          CHART_VERSION=$(grep -roh 'version: "[0-9][^"]*"' infrastructure/yaook-operator/ \
+            | head -1 | grep -o '"[^"]*"' | tr -d '"')
+          echo "Current chart version: $CHART_VERSION"
 
-          # Components and their source file paths in the yaook repo.
-          # Each component's __init__.py (or cr.py for nova) contains a
-          # RELEASES = [...] list that defines the supported OpenStack releases.
+          # 2. Find the matching tag in the yaook GitLab repo.
+          #    Tags follow the pattern "v{chart_version}" (e.g. v3.0.0).
+          TAG="v${CHART_VERSION}"
+          TAG_EXISTS=$(curl -s -o /dev/null -w "%{http_code}" \
+            "https://gitlab.com/api/v4/projects/yaook%2Foperator/repository/tags/${TAG}")
+          if [ "$TAG_EXISTS" != "200" ]; then
+            echo "WARNING: Tag $TAG not found on GitLab, falling back to default branch"
+            PROJECT_INFO=$(curl -s "https://gitlab.com/api/v4/projects/yaook%2Foperator")
+            REF=$(echo "$PROJECT_INFO" | jq -r '.default_branch')
+            TAG_INFO="(default branch: $REF)"
+          else
+            REF="$TAG"
+            TAG_INFO="(tag: $TAG)"
+          fi
+          echo "Using ref: $REF $TAG_INFO"
+          echo "ref=$REF" >> "$GITHUB_OUTPUT"
+          echo "tag_info=$TAG_INFO" >> "$GITHUB_OUTPUT"
+
+          # 3. Components and their source file paths in the yaook repo.
+          #    Each component has a RELEASES = [...] list in its Python source.
           declare -A COMPONENT_FILES=(
             [keystone]="yaook/op/keystone/cr.py"
             [nova]="yaook/op/nova/cr.py"
@@ -34,41 +53,43 @@ jobs:
             [designate]="yaook/op/designate/__init__.py"
           )
 
-          # Collect all unique releases across all components
+          # 4. Collect all unique releases across all components
           ALL_RELEASES=""
 
           for component in "${!COMPONENT_FILES[@]}"; do
             file_path="${COMPONENT_FILES[$component]}"
             encoded_path=$(python3 -c "import urllib.parse; print(urllib.parse.quote('$file_path', safe=''))")
 
-            content=$(curl -s "https://gitlab.com/api/v4/projects/yaook%2Foperator/repository/files/${encoded_path}/raw?ref=${YAOOK_DEFAULT}")
+            content=$(curl -s "https://gitlab.com/api/v4/projects/yaook%2Foperator/repository/files/${encoded_path}/raw?ref=${REF}")
 
-            # Extract the RELEASES list from the Python source.
-            # The list is formatted as:
-            #   RELEASES = [
-            #       "2025.1",
-            #       "2026.1",
-            #   ]
-            # We extract everything between RELEASES = [ and the closing ],
-            releases=$(echo "$content" | python3 -c "
+            if echo "$content" | jq -e '.message' >/dev/null 2>&1; then
+              echo "WARNING: Failed to fetch $file_path: $(echo "$content" | jq -r '.message')"
+              continue
+            fi
+
+            tmpfile=$(mktemp)
+            echo "$content" > "$tmpfile"
+            releases=$(python3 -c "
           import sys, re
-          text = sys.stdin.read()
+          with open(sys.argv[1]) as f:
+              text = f.read()
           m = re.search(r'RELEASES\s*=\s*\[(.*?)\]', text, re.DOTALL)
           if m:
               for line in m.group(1).splitlines():
                   line = line.strip().strip(',').strip('\"').strip(\"'\")
                   if re.match(r'^\d{4}\.\d+$', line):
                       print(line)
-          ")
+          " "$tmpfile")
+            rm -f "$tmpfile"
 
             echo "Component $component releases: $(echo $releases | tr '\n' ' ')"
             ALL_RELEASES="$ALL_RELEASES
           $releases"
           done
 
-          # Deduplicate and sort
-          UNIQUE_RELEASES=$(echo "$ALL_RELEASES" | sort -u | grep -v '^$')
-          echo "All unique yaook releases:"
+          # Deduplicate and sort (version sort: 2025.1 < 2025.2 < 2026.1)
+          UNIQUE_RELEASES=$(echo "$ALL_RELEASES" | sort -t. -k1,1n -k2,2n -u | grep -v '^$')
+          echo "All unique yaook releases for $REF:"
           echo "$UNIQUE_RELEASES"
           echo "releases<<EOF" >> "$GITHUB_OUTPUT"
           echo "$UNIQUE_RELEASES" >> "$GITHUB_OUTPUT"
@@ -77,7 +98,6 @@ jobs:
       - name: Check current targetRelease in CRs
         id: current
         run: |
-          # Find all targetRelease values in our yaook CRs
           CURRENT=$(grep -roh 'targetRelease: "[0-9]\{4\}\.[0-9]*"' infrastructure/yaook/ | grep -o '"[0-9]\{4\}\.[0-9]*"' | tr -d '"' | sort -u)
           echo "Current targetRelease values:"
           echo "$CURRENT"
@@ -90,13 +110,10 @@ jobs:
         run: |
           CURRENT="${{ steps.current.outputs.releases }}"
           AVAILABLE="${{ steps.fetch.outputs.releases }}"
-
-          # For each current release, find the latest available release
-          # that is >= the current one.
           LATEST_AVAILABLE=$(echo "$AVAILABLE" | tail -1)
 
-          echo "Current releases: $CURRENT"
-          echo "Latest available: $LATEST_AVAILABLE"
+          echo "Current: $CURRENT"
+          echo "Latest available for our chart version: $LATEST_AVAILABLE"
 
           NEEDS_UPGRADE=false
 
@@ -117,8 +134,6 @@ jobs:
         run: |
           TARGET="${{ steps.upgrade.outputs.target }}"
           echo "Updating all yaook CRs to targetRelease: $TARGET"
-
-          # Update targetRelease in all yaook deployment CRs
           for f in infrastructure/yaook/*.yaml; do
             if grep -q 'targetRelease:' "$f"; then
               sed -i "s/targetRelease:.*/targetRelease: \"$TARGET\"/" "$f"
@@ -136,9 +151,11 @@ jobs:
           body: |
             Automated upgrade of all yaook OpenStack service deployments to release **${{ steps.upgrade.outputs.target }}**.
 
-            **Source:** [yaook/operator](https://gitlab.com/yaook/operator) commit `${{ steps.fetch.outputs.yaook_commit }}`
+            **Operator chart version:** ${{ steps.fetch.outputs.ref }} ${{ steps.fetch.outputs.tag_info }}
 
-            Supported releases per component (from operator source):
+            **Source:** [yaook/operator](https://gitlab.com/yaook/operator)
+
+            Supported releases per component (from operator source at ${{ steps.fetch.outputs.ref }}):
             ```
             ${{ steps.fetch.outputs.releases }}
             ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1818,6 +1818,21 @@ dedicated `.github/workflows/npins-update.yaml` workflow runs `npins update`
 across ALL pins every 6h and opens correct PRs with refreshed hashes — it is the
 sole owner of npins updates (sveltosctl, nixpkgs, etc.).
 
+**yaook OpenStack releases are NOT managed by Renovate.** The yaook operator
+supports multiple OpenStack releases (e.g. `2025.1`, `2026.1`) via the
+`targetRelease` field in each Deployment CR. New releases are defined in the
+operator's Python source (`RELEASES = [...]` in each component's `__init__.py`
+or `cr.py`). Because there is no public registry or datasource for these
+version strings, Renovate cannot track them. The dedicated
+`.github/workflows/yaook-releases.yaml` workflow runs weekly (Monday 03:00 UTC)
+and on-demand: it fetches the yaook operator source from GitLab, extracts the
+`RELEASES` lists from all components, compares them to the `targetRelease` in
+our CRs (`infrastructure/yaook/*.yaml`), and opens a PR to upgrade if a newer
+release is available. All 8 CRs are updated together (keystone, nova, glance,
+neutron, cinder, horizon, octavia, designate). Barbican is not currently
+deployed. **Before merging:** verify the upgrade path is valid — check the
+[yaook upgrade docs](https://yaook.cloud/docs/) for breaking changes.
+
 **Grouping (packageRules):** yaook operators (shared 2.2.0), openstack
 cloud-provider (CCM + Cinder CSI + their images), cluster-api providers, cilium
 (HelmRelease + Sveltos inline kept in sync), flux-operator (HelmRelease +
@@ -2252,7 +2267,7 @@ All configuration is declarative, version-controlled, and enables auditable infr
 
 ---
 
-**Last Updated**: July 2026 (Renovate is now self-hosted in GitHub Actions: new `.github/workflows/renovate.yaml` runs the `renovatebot/github-action` hourly + on-dispatch, minting a token from the `rpcu-bot` GitHub App via `actions/create-github-app-token`, reusing the org-level `APP_ID`/`PRIVATE_KEY` secrets. Replaces the Mend-hosted App. See "Dependency Updates (Renovate)" in Section 5. — Prior: 2026-07-10 Ceph OSD-full incident: `osd.2`/quinn hit 95% full_ratio and blocked writes cluster-wide at only ~73% cluster usage because `rpcu-fs-data0` — ~70% of the data — was left at `pg_num: 32`, splitting 26/19/19 across the 3 OSDs; the PG-count upmap balancer couldn't correct the byte skew. Fixed live by splitting `rpcu-fs-data0` pg_num 32→128 + `upmap_max_deviation 1` + `osd_mclock_profile high_recovery_ops` for the drain; `infrastructure/rook/configs/cephfilesystem.yaml` `data0` pool now declares `pg_autoscale_mode: on` + `target_size_ratio: 0.8` so it never collapses back to 32. See the new "Ceph single OSD full from too-few PGs on the dominant pool" note in Section 8. Prior update — NFS resilience after the 2026-07-06/07 incidents: `cephnfs.yaml` gateway now has `system-cluster-critical` priority + resources + a relaxed liveness probe; new `nfs-export-ensure.yaml` CronJob declaratively enforces the export incl. `security_label: false`; `infrastructure/kamaji/values.yaml` adds `required` etcd pod anti-affinity so etcd members spread across mgmt nodes and one node event no longer degrades every tenant control plane)
+**Last Updated**: July 2026 (New `.github/workflows/yaook-releases.yaml` workflow: scrapes yaook operator GitLab source weekly to detect new OpenStack releases and opens upgrade PRs for all yaook Deployment CRs. Renovate is now self-hosted in GitHub Actions: new `.github/workflows/renovate.yaml` runs the `renovatebot/github-action` hourly + on-dispatch, minting a token from the `rpcu-bot` GitHub App via `actions/create-github-app-token`, reusing the org-level `APP_ID`/`PRIVATE_KEY` secrets. Replaces the Mend-hosted App. See "Dependency Updates (Renovate)" in Section 5. — Prior: 2026-07-10 Ceph OSD-full incident: `osd.2`/quinn hit 95% full_ratio and blocked writes cluster-wide at only ~73% cluster usage because `rpcu-fs-data0` — ~70% of the data — was left at `pg_num: 32`, splitting 26/19/19 across the 3 OSDs; the PG-count upmap balancer couldn't correct the byte skew. Fixed live by splitting `rpcu-fs-data0` pg_num 32→128 + `upmap_max_deviation 1` + `osd_mclock_profile high_recovery_ops` for the drain; `infrastructure/rook/configs/cephfilesystem.yaml` `data0` pool now declares `pg_autoscale_mode: on` + `target_size_ratio: 0.8` so it never collapses back to 32. See the new "Ceph single OSD full from too-few PGs on the dominant pool" note in Section 8. Prior update — NFS resilience after the 2026-07-06/07 incidents: `cephnfs.yaml` gateway now has `system-cluster-critical` priority + resources + a relaxed liveness probe; new `nfs-export-ensure.yaml` CronJob declaratively enforces the export incl. `security_label: false`; `infrastructure/kamaji/values.yaml` adds `required` etcd pod anti-affinity so etcd members spread across mgmt nodes and one node event no longer degrades every tenant control plane)
 **Repository**: <https://github.com/RPCU/argus.git>
 **Main Branch**: main
 **Clusters**: OpenStack, mgmt (Cluster API management)


### PR DESCRIPTION
## Changes

1. **fix(nova): add `remote_filesystem_transport: rsync`** — fixes cold migration SCP/SFTP protocol issue (OpenSSH 9+ defaults to SFTP which is blocked by restricted-ssh-commands)
2. **feat(yaook-releases): add weekly workflow** — scrapes yaook operator GitLab source weekly, detects new OpenStack releases, opens upgrade PRs
3. **fix(yaook-releases): use correct output name** — `steps.current.outputs.releases` → `steps.current.outputs.current` so the current targetRelease is properly read

## PR: https://github.com/RPCU/argus/pull/new/fdgdfg