### PR TITLE
fix(yaook-releases): check per-component release support

### DIFF
--- a/.github/workflows/yaook-releases.yaml
+++ b/.github/workflows/yaook-releases.yaml
@@ -13,7 +13,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Fetch supported releases from yaook operator
+      - name: Fetch supported releases per component from yaook operator
         id: fetch
         run: |
           # 1. Read our current yaook operator chart version from the
@@ -23,7 +23,6 @@ jobs:
           echo "Current chart version: $CHART_VERSION"
 
           # 2. Find the matching tag in the yaook GitLab repo.
-          #    Tags follow the pattern "v{chart_version}" (e.g. v3.0.0).
           TAG="v${CHART_VERSION}"
           TAG_EXISTS=$(curl -s -o /dev/null -w "%{http_code}" \
             "https://gitlab.com/api/v4/projects/yaook%2Foperator/repository/tags/${TAG}")
@@ -37,11 +36,8 @@ jobs:
             TAG_INFO="(tag: $TAG)"
           fi
           echo "Using ref: $REF $TAG_INFO"
-          echo "ref=$REF" >> "$GITHUB_OUTPUT"
-          echo "tag_info=$TAG_INFO" >> "$GITHUB_OUTPUT"
 
           # 3. Components and their source file paths in the yaook repo.
-          #    Each component has a RELEASES = [...] list in its Python source.
           declare -A COMPONENT_FILES=(
             [keystone]="yaook/op/keystone/cr.py"
             [nova]="yaook/op/nova/cr.py"
@@ -53,9 +49,9 @@ jobs:
             [designate]="yaook/op/designate/__init__.py"
           )
 
-          # 4. Collect all unique releases across all components
-          ALL_RELEASES=""
-
+          # 4. Fetch per-component releases and build a mapping file.
+          #    Output format: one line per component: "component=release1,release2,..."
+          RELEASE_MAP=""
           for component in "${!COMPONENT_FILES[@]}"; do
             file_path="${COMPONENT_FILES[$component]}"
             encoded_path=$(python3 -c "import urllib.parse; print(urllib.parse.quote('$file_path', safe=''))")
@@ -82,63 +78,89 @@ jobs:
           " "$tmpfile")
             rm -f "$tmpfile"
 
-            echo "Component $component releases: $(echo $releases | tr '\n' ' ')"
-            ALL_RELEASES="$ALL_RELEASES
-          $releases"
+            # Sort releases for this component
+            sorted_releases=$(echo "$releases" | sort -t. -k1,1n -k2,2n | tr '\n' ',' | sed 's/,$//')
+            echo "Component $component: $sorted_releases"
+            RELEASE_MAP="${RELEASE_MAP}${component}=${sorted_releases}\n"
           done
 
-          # Deduplicate and sort (version sort: 2025.1 < 2025.2 < 2026.1)
-          UNIQUE_RELEASES=$(echo "$ALL_RELEASES" | sort -t. -k1,1n -k2,2n -u | grep -v '^$')
-          echo "All unique yaook releases for $REF:"
-          echo "$UNIQUE_RELEASES"
-          echo "releases<<EOF" >> "$GITHUB_OUTPUT"
-          echo "$UNIQUE_RELEASES" >> "$GITHUB_OUTPUT"
+          echo "release_map<<EOF" >> "$GITHUB_OUTPUT"
+          echo -e "$RELEASE_MAP" >> "$GITHUB_OUTPUT"
           echo "EOF" >> "$GITHUB_OUTPUT"
+          echo "ref=$REF" >> "$GITHUB_OUTPUT"
+          echo "tag_info=$TAG_INFO" >> "$GITHUB_OUTPUT"
 
-      - name: Check current targetRelease in CRs
-        id: current
-        run: |
-          CURRENT=$(grep -roh 'targetRelease: "[0-9]\{4\}\.[0-9]*"' infrastructure/yaook/ | grep -o '"[0-9]\{4\}\.[0-9]*"' | tr -d '"' | sort -u)
-          echo "Current targetRelease values:"
-          echo "$CURRENT"
-          echo "current<<EOF" >> "$GITHUB_OUTPUT"
-          echo "$CURRENT" >> "$GITHUB_OUTPUT"
-          echo "EOF" >> "$GITHUB_OUTPUT"
-
-      - name: Determine upgrade target
+      - name: Determine per-component upgrades
         id: upgrade
         run: |
-          CURRENT="${{ steps.current.outputs.current }}"
-          AVAILABLE="${{ steps.fetch.outputs.releases }}"
-          LATEST_AVAILABLE=$(echo "$AVAILABLE" | tail -1)
+          RELEASE_MAP="${{ steps.fetch.outputs.release_map }}"
 
-          echo "Current: $CURRENT"
-          echo "Latest available for our chart version: $LATEST_AVAILABLE"
+          # For each CR, find its component, look up the latest supported
+          # release, and decide whether it needs an upgrade.
+          UPGRADE_NEEDED=false
+          CHANGES=""
 
-          NEEDS_UPGRADE=false
-
-          while IFS= read -r cur; do
-            [ -z "$cur" ] && continue
-            if [ "$cur" != "$LATEST_AVAILABLE" ]; then
-              echo "Upgrade needed: $cur -> $LATEST_AVAILABLE"
-              NEEDS_UPGRADE=true
-              TARGET="$LATEST_AVAILABLE"
+          for f in infrastructure/yaook/*.yaml; do
+            if ! grep -q 'targetRelease:' "$f"; then
+              continue
             fi
-          done <<< "$CURRENT"
 
-          echo "needs_upgrade=$NEEDS_UPGRADE" >> "$GITHUB_OUTPUT"
-          echo "target=$TARGET" >> "$GITHUB_OUTPUT"
+            # Determine component name from filename
+            basename=$(basename "$f" .yaml)
+            case "$basename" in
+              keystone|nova|glance|neutron|cinder|horizon|octavia|designate)
+                component="$basename"
+                ;;
+              *)
+                echo "WARNING: Unknown component for $f, skipping"
+                continue
+                ;;
+            esac
 
-      - name: Update targetRelease in CRs
+            # Get current targetRelease from this CR
+            current=$(grep 'targetRelease:' "$f" | head -1 | grep -o '"[0-9]\{4\}\.[0-9]*"' | tr -d '"')
+            if [ -z "$current" ]; then
+              echo "WARNING: No targetRelease found in $f, skipping"
+              continue
+            fi
+
+            # Look up the latest release supported by this component
+            component_line=$(echo -e "$RELEASE_MAP" | grep "^${component}=")
+            component_releases=$(echo "$component_line" | cut -d= -f2)
+            latest=$(echo "$component_releases" | tr ',' '\n' | sort -t. -k1,1n -k2,2n | tail -1)
+
+            echo "$f ($component): current=$current latest_supported=$latest"
+
+            if [ "$current" != "$latest" ]; then
+              echo "  -> Upgrade: $current -> $latest"
+              CHANGES="${CHANGES}${f}|${component}|${current}|${latest}\n"
+              UPGRADE_NEEDED=true
+            fi
+          done
+
+          echo "needs_upgrade=$UPGRADE_NEEDED" >> "$GITHUB_OUTPUT"
+          echo "changes<<EOF" >> "$GITHUB_OUTPUT"
+          echo -e "$CHANGES" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+
+      - name: Apply upgrades
         if: steps.upgrade.outputs.needs_upgrade == 'true'
         run: |
-          TARGET="${{ steps.upgrade.outputs.target }}"
-          echo "Updating all yaook CRs to targetRelease: $TARGET"
-          for f in infrastructure/yaook/*.yaml; do
-            if grep -q 'targetRelease:' "$f"; then
-              sed -i "s/targetRelease:.*/targetRelease: \"$TARGET\"/" "$f"
-              echo "Updated $f"
-            fi
+          CHANGES="${{ steps.upgrade.outputs.changes }}"
+
+          echo "=== Upgrade plan ==="
+          echo -e "$CHANGES" | while IFS='|' read -r file component current target; do
+            [ -z "$file" ] && continue
+            echo "  $component: $current -> $target ($file)"
+          done
+          echo "==================="
+
+          # Apply changes and collect per-component details for PR body
+          SUMMARY=""
+          echo -e "$CHANGES" | while IFS='|' read -r file component current target; do
+            [ -z "$file" ] && continue
+            sed -i "s/targetRelease:.*/targetRelease: \"$target\"/" "$file"
+            echo "Updated $file: $current -> $target"
           done
 
       - name: Create Pull Request
@@ -146,21 +168,22 @@ jobs:
         uses: peter-evans/create-pull-request@v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          commit-message: "chore(yaook): upgrade OpenStack release to ${{ steps.upgrade.outputs.target }}"
-          title: "chore(yaook): upgrade OpenStack release to ${{ steps.upgrade.outputs.target }}"
+          commit-message: "chore(yaook): upgrade OpenStack releases"
+          title: "chore(yaook): upgrade OpenStack releases"
           body: |
-            Automated upgrade of all yaook OpenStack service deployments to release **${{ steps.upgrade.outputs.target }}**.
+            Automated upgrade of yaook OpenStack service deployments.
 
             **Operator chart version:** ${{ steps.fetch.outputs.ref }} ${{ steps.fetch.outputs.tag_info }}
 
             **Source:** [yaook/operator](https://gitlab.com/yaook/operator)
 
-            Supported releases per component (from operator source at ${{ steps.fetch.outputs.ref }}):
+            ### Per-component upgrade plan
+
             ```
-            ${{ steps.fetch.outputs.releases }}
+            ${{ steps.upgrade.outputs.changes }}
             ```
 
-            This PR updates `targetRelease` in all `infrastructure/yaook/*.yaml` CRs.
+            Each component is upgraded to the **latest release supported by its operator at chart ${{ steps.fetch.outputs.ref }}**. Components that already support the latest release are not changed.
 
             **Before merging:** verify the upgrade path is valid for your deployment. Check the [yaook upgrade documentation](https://yaook.cloud/docs/) for any breaking changes between releases.
           branch: "yaook-release-upgrade"


### PR DESCRIPTION
Different yaook components support different OpenStack releases at the same chart version. The previous workflow took the union of all releases and proposed the global latest, which broke components with narrower support (e.g. Designate at v3.0.0 only supports up to 2025.1, not 2026.1).

Now each CR is checked against its own component's RELEASES list, and only upgraded to the latest release that specific component supports.