### PR TITLE
fix(yaook-releases): use intersection of all component releases, never downgrade

### DIFF
--- a/.github/workflows/yaook-releases.yaml
+++ b/.github/workflows/yaook-releases.yaml
@@ -95,50 +95,75 @@ jobs:
         run: |
           RELEASE_MAP="${{ steps.fetch.outputs.release_map }}"
 
-          # For each CR, find its component, look up the latest supported
-          # release, and decide whether it needs an upgrade.
+          # Step 1: Find the INTERSECTION of all supported releases.
+          # All components must support the target release for compatibility.
+          INTERSECTION=""
+          FIRST=true
+          for component in keystone nova glance neutron cinder horizon octavia designate; do
+            component_line=$(echo -e "$RELEASE_MAP" | grep "^${component}=")
+            component_releases=$(echo "$component_line" | cut -d= -f2 | tr ',' '\n')
+
+            if [ "$FIRST" = true ]; then
+              INTERSECTION="$component_releases"
+              FIRST=false
+            else
+              # Keep only releases present in both
+              INTERSECTION=$(comm -12 <(echo "$INTERSECTION" | sort -t. -k1,1n -k2,2n) \
+                                        <(echo "$component_releases" | sort -t. -k1,1n -k2,2n))
+            fi
+            echo "After $component intersection: $(echo $INTERSECTION | tr '\n' ' ')"
+          done
+
+          LATEST_SUPPORTED=$(echo "$INTERSECTION" | tail -1)
+          echo "Latest release supported by ALL components: $LATEST_SUPPORTED"
+
+          # Step 2: Check each CR — only propose an upgrade (never a downgrade)
           UPGRADE_NEEDED=false
           CHANGES=""
+          CURRENT_MAX=""
 
           for f in infrastructure/yaook/*.yaml; do
             if ! grep -q 'targetRelease:' "$f"; then
               continue
             fi
 
-            # Determine component name from filename
             basename=$(basename "$f" .yaml)
             case "$basename" in
               keystone|nova|glance|neutron|cinder|horizon|octavia|designate)
-                component="$basename"
-                ;;
-              *)
-                echo "WARNING: Unknown component for $f, skipping"
-                continue
-                ;;
+                component="$basename" ;;
+              *) continue ;;
             esac
 
-            # Get current targetRelease from this CR
             current=$(grep 'targetRelease:' "$f" | head -1 | grep -o '"[0-9]\{4\}\.[0-9]*"' | tr -d '"')
-            if [ -z "$current" ]; then
-              echo "WARNING: No targetRelease found in $f, skipping"
-              continue
+            [ -z "$current" ] && continue
+
+            # Track highest current version across all CRs
+            if [ -z "$CURRENT_MAX" ] || [ "$(printf '%s\n%s' "$CURRENT_MAX" "$current" | sort -t. -k1,1n -k2,2n | tail -1)" = "$current" ]; then
+              CURRENT_MAX="$current"
             fi
 
-            # Look up the latest release supported by this component
-            component_line=$(echo -e "$RELEASE_MAP" | grep "^${component}=")
-            component_releases=$(echo "$component_line" | cut -d= -f2)
-            latest=$(echo "$component_releases" | tr ',' '\n' | sort -t. -k1,1n -k2,2n | tail -1)
-
-            echo "$f ($component): current=$current latest_supported=$latest"
-
-            if [ "$current" != "$latest" ]; then
-              echo "  -> Upgrade: $current -> $latest"
-              CHANGES="${CHANGES}${f}|${component}|${current}|${latest}\n"
-              UPGRADE_NEEDED=true
-            fi
+            echo "$f ($component): current=$current"
           done
 
+          echo "Highest current targetRelease across all CRs: $CURRENT_MAX"
+
+          # Only create a PR if LATEST_SUPPORTED > CURRENT_MAX (real upgrade)
+          # Use version comparison: sort both, check if LATEST is on last line
+          SORTED=$(printf '%s\n%s\n' "$CURRENT_MAX" "$LATEST_SUPPORTED" | sort -t. -k1,1n -k2,2n | tail -1)
+
+          if [ "$SORTED" = "$LATEST_SUPPORTED" ] && [ "$CURRENT_MAX" != "$LATEST_SUPPORTED" ]; then
+            echo "Upgrade available: $CURRENT_MAX -> $LATEST_SUPPORTED"
+            UPGRADE_NEEDED=true
+            for f in infrastructure/yaook/*.yaml; do
+              grep -q 'targetRelease:' "$f" || continue
+              CHANGES="${CHANGES}${f}\n"
+            done
+          else
+            echo "All CRs already at the latest supported release ($CURRENT_MAX)"
+          fi
+
           echo "needs_upgrade=$UPGRADE_NEEDED" >> "$GITHUB_OUTPUT"
+          echo "target=$LATEST_SUPPORTED" >> "$GITHUB_OUTPUT"
           echo "changes<<EOF" >> "$GITHUB_OUTPUT"
           echo -e "$CHANGES" >> "$GITHUB_OUTPUT"
           echo "EOF" >> "$GITHUB_OUTPUT"
@@ -146,21 +171,14 @@ jobs:
       - name: Apply upgrades
         if: steps.upgrade.outputs.needs_upgrade == 'true'
         run: |
+          TARGET="${{ steps.upgrade.outputs.target }}"
           CHANGES="${{ steps.upgrade.outputs.changes }}"
 
-          echo "=== Upgrade plan ==="
-          echo -e "$CHANGES" | while IFS='|' read -r file component current target; do
-            [ -z "$file" ] && continue
-            echo "  $component: $current -> $target ($file)"
-          done
-          echo "==================="
-
-          # Apply changes and collect per-component details for PR body
-          SUMMARY=""
-          echo -e "$CHANGES" | while IFS='|' read -r file component current target; do
-            [ -z "$file" ] && continue
-            sed -i "s/targetRelease:.*/targetRelease: \"$target\"/" "$file"
-            echo "Updated $file: $current -> $target"
+          echo "=== Upgrade plan: all CRs -> $TARGET ==="
+          echo -e "$CHANGES" | while read -r f; do
+            [ -z "$f" ] && continue
+            sed -i "s/targetRelease:.*/targetRelease: \"$TARGET\"/" "$f"
+            echo "Updated $f"
           done
 
       - name: Create Pull Request
@@ -168,22 +186,16 @@ jobs:
         uses: peter-evans/create-pull-request@v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          commit-message: "chore(yaook): upgrade OpenStack releases"
-          title: "chore(yaook): upgrade OpenStack releases"
+          commit-message: "chore(yaook): upgrade OpenStack release to ${{ steps.upgrade.outputs.target }}"
+          title: "chore(yaook): upgrade OpenStack release to ${{ steps.upgrade.outputs.target }}"
           body: |
-            Automated upgrade of yaook OpenStack service deployments.
+            Automated upgrade of all yaook OpenStack service deployments to release **${{ steps.upgrade.outputs.target }}**.
 
             **Operator chart version:** ${{ steps.fetch.outputs.ref }} ${{ steps.fetch.outputs.tag_info }}
 
             **Source:** [yaook/operator](https://gitlab.com/yaook/operator)
 
-            ### Per-component upgrade plan
-
-            ```
-            ${{ steps.upgrade.outputs.changes }}
-            ```
-
-            Each component is upgraded to the **latest release supported by its operator at chart ${{ steps.fetch.outputs.ref }}**. Components that already support the latest release are not changed.
+            This release is supported by **all** 8 components at chart ${{ steps.fetch.outputs.ref }} (verified via intersection of per-component `RELEASES` lists).
 
             **Before merging:** verify the upgrade path is valid for your deployment. Check the [yaook upgrade documentation](https://yaook.cloud/docs/) for any breaking changes between releases.
           branch: "yaook-release-upgrade"


### PR DESCRIPTION
Computes the INTERSECTION of all 8 components' RELEASES lists and only proposes an upgrade when the latest intersection is strictly greater than the current max. Never proposes a downgrade.