### PR TITLE
fix(horizon): revert targetRelease to 2025.1

### DIFF
--- a/infrastructure/yaook/horizon.yaml
+++ b/infrastructure/yaook/horizon.yaml
@@ -16,4 +16,4 @@ spec:
     port: 443
   issuerRef:
     name: yaook-internal
-  targetRelease: "2026.1"
+  targetRelease: "2025.1"


### PR DESCRIPTION
Yaook only supports upgrading one release at a time. The broken yaook-releases workflow bumped horizon to 2026.1 but the operator rejects the jump from 2025.1 directly to 2026.1.