### PR TITLE
fix(cilium): override MTU to 1292 for VXLAN tunnel overhead

### DIFF
--- a/infrastructure/cilium/values.yaml
+++ b/infrastructure/cilium/values.yaml
@@ -8,16 +8,16 @@ socketLB:
   # clusters/openstack/cilium.yaml.
   hostNamespaceOnly: false
 kubeProxyReplacement: true
-# TCP MSS clamping: ensure TCP SYN MSS options account for VXLAN overhead
-# (50 bytes). Without this, the pod's TCP stack negotiates MSS based on the
-# veth MTU (which equals the device MTU, 1342), producing segments of 1302B.
-# After VXLAN encapsulation (+50B = 1352B) these exceed the physical NIC MTU
-# (1342) and are silently dropped by packetization-layer-pmtud-mode: blackhole
-# — TCP connect (small SYN/ACK) succeeds but TLS (multi-segment ServerHello +
-# Certificate) hangs until timeout. Clamping rewrites the MSS to 1252 so
-# segments fit the VXLAN path after encapsulation.
-mssClamping:
-  enabled: true
+# Override auto-detected MTU (default 0 = auto-detect from physical NIC).
+# The physical NIC MTU is 1342, but VXLAN encapsulation adds 50 bytes of
+# overhead. Cilium auto-detects 1342 and sets both cilium_vxlan and the pod
+# veth to 1342 — the pod TCP stack then negotiates MSS=1302 (1342-40 headers),
+# which after VXLAN encapsulation becomes 1352B, exceeding the physical NIC
+# MTU and being silently dropped by packetization-layer-pmtud-mode: blackhole.
+# Setting MTU=1292 forces the pod veth to 1292 so TCP MSS=1252; after VXLAN
+# +50B = 1302B < 1342. This fixes TLS (large multi-segment handshakes) while
+# TCP SYN/ACK (tiny packets) was always fine.
+MTU: 1292
 envoy:
   enabled: false
 cni:

--- a/infrastructure/sveltos/clusterprofiles/cilium.yaml
+++ b/infrastructure/sveltos/clusterprofiles/cilium.yaml
@@ -62,8 +62,7 @@ spec:
           enabled: false
         socketLB:
           hostNamespaceOnly: false
-        mssClamping:
-          enabled: true
+        MTU: 1292
         envoy:
           enabled: false
         cni:


### PR DESCRIPTION
Previous mssClamping was silently ignored by Cilium 1.19.6 (option doesn't exist). Use the correct mechanism: set MTU=1292 so pod veth drops from 1342→1292, TCP MSS=1252, after VXLAN +50B=1302B < 1342 physical NIC MTU.