### PR TITLE
revert(cilium): remove MTU override that regressed local TLS

### DIFF
--- a/infrastructure/cilium/values.yaml
+++ b/infrastructure/cilium/values.yaml
@@ -8,16 +8,6 @@ socketLB:
   # clusters/openstack/cilium.yaml.
   hostNamespaceOnly: false
 kubeProxyReplacement: true
-# Override auto-detected MTU (default 0 = auto-detect from physical NIC).
-# The physical NIC MTU is 1342, but VXLAN encapsulation adds 50 bytes of
-# overhead. Cilium auto-detects 1342 and sets both cilium_vxlan and the pod
-# veth to 1342 — the pod TCP stack then negotiates MSS=1302 (1342-40 headers),
-# which after VXLAN encapsulation becomes 1352B, exceeding the physical NIC
-# MTU and being silently dropped by packetization-layer-pmtud-mode: blackhole.
-# Setting MTU=1292 forces the pod veth to 1292 so TCP MSS=1252; after VXLAN
-# +50B = 1302B < 1342. This fixes TLS (large multi-segment handshakes) while
-# TCP SYN/ACK (tiny packets) was always fine.
-MTU: 1292
 envoy:
   enabled: false
 cni:

--- a/infrastructure/sveltos/clusterprofiles/cilium.yaml
+++ b/infrastructure/sveltos/clusterprofiles/cilium.yaml
@@ -62,7 +62,6 @@ spec:
           enabled: false
         socketLB:
           hostNamespaceOnly: false
-        MTU: 1292
         envoy:
           enabled: false
         cni:


### PR DESCRIPTION
Reverts the MTU=1292 override. It made cross-node TLS worse AND broke local TLS (0/10).