### PR TITLE
cilium: change packetizationLayerPMTUDMode from blackhole to native

### DIFF
--- a/infrastructure/cilium/values.yaml
+++ b/infrastructure/cilium/values.yaml
@@ -1,3 +1,4 @@
+packetizationLayerPMTUDMode: native
 l2announcements:
   enabled: true
 socketLB:

--- a/infrastructure/sveltos/clusterprofiles/cilium.yaml
+++ b/infrastructure/sveltos/clusterprofiles/cilium.yaml
@@ -58,6 +58,7 @@ spec:
         k8sServiceHost: "{{ .Cluster.spec.controlPlaneEndpoint.host }}"
         k8sServicePort: "{{ .Cluster.spec.controlPlaneEndpoint.port }}"
         kubeProxyReplacement: true
+        packetizationLayerPMTUDMode: native
         l2announcements:
           enabled: false
         socketLB:


### PR DESCRIPTION
## Root cause

With `blackhole` mode, Cilium silently drops any inner packet that exceeds the route MTU (`cilium_vxlan MTU - 50 bytes VXLAN overhead`).

**The MTU mismatch is structural**: pod veth MTU equals `cilium_vxlan` MTU, but the host route to remote subnets has MTU = `cilium_vxlan - 50` (VXLAN overhead). Pod TCP MSS = veth MTU - 40, which exceeds the route MTU by 10 bytes. Every cross-node TCP segment larger than the route MTU gets blackholed.

| Setting | veth MTU | Route MTU | MSS | Result |
|---------|----------|-----------|-----|--------|
| auto-detect (1342) | 1342 | 1292 | 1302 | 1302 > 1292 → blackhole |
| explicit 1292 | 1292 | 1242 | 1252 | 1252 > 1242 → blackhole |

SYN/ACK (tiny packets ~60 bytes) always works. TLS handshakes (multi-segment ServerHello/Certificate ~1200 bytes each) always fail cross-node.

## Fix

Change `packetizationLayerPMTUDMode` from `blackhole` to `native`. This lets the kernel send ICMP 'fragmentation needed' back to the pod, triggering TCP PMTU discovery so the pod reduces its packet size.

Applied to both the shared base values (mgmt/openstack clusters) and the Sveltos Cilium profile (workload clusters).

## Test plan

After merge, from a regular pod on mgmt:
- TLS to cross-node pod should now succeed (previously 0/10)
- Local TLS should remain 10/10