### PR TITLE
cilium: fix PMTU discovery with correct nested Helm values path

### DIFF
--- a/infrastructure/cilium/values.yaml
+++ b/infrastructure/cilium/values.yaml
@@ -1,4 +1,6 @@
-packetizationLayerPMTUDMode: native
+pmtuDiscovery:
+  enabled: true
+  packetizationLayerPMTUDMode: "always"
 l2announcements:
   enabled: true
 socketLB:

--- a/infrastructure/sveltos/clusterprofiles/cilium.yaml
+++ b/infrastructure/sveltos/clusterprofiles/cilium.yaml
@@ -58,7 +58,9 @@ spec:
         k8sServiceHost: "{{ .Cluster.spec.controlPlaneEndpoint.host }}"
         k8sServicePort: "{{ .Cluster.spec.controlPlaneEndpoint.port }}"
         kubeProxyReplacement: true
-        packetizationLayerPMTUDMode: native
+        pmtuDiscovery:
+          enabled: true
+          packetizationLayerPMTUDMode: "always"
         l2announcements:
           enabled: false
         socketLB:


### PR DESCRIPTION
## What this fixes

PR #404 set `packetizationLayerPMTUDMode` at the **top level** of `values.yaml`, but Helm silently ignored it — the value must be nested under `pmtuDiscovery:`:

```yaml
pmtuDiscovery:
  enabled: true
  packetizationLayerPMTUDMode: "always"
```

Also enables `pmtuDiscovery.enabled` (default `false`) which is required for the feature to activate.

## Validation

```
$ helm template cilium cilium/cilium --version 1.19.6 -f infrastructure/cilium/values.yaml | grep pmtu
  enable-pmtu-discovery: "true"
  packetization-layer-pmtud-mode: "always"
```

Supersedes #404 (which had the correct intent but wrong value path).