### PR TITLE
fix(cilium): correct MTU key to uppercase (MTU) for Cilium Helm chart

### DIFF
--- a/clusters/mgmt/cilium.yaml
+++ b/clusters/mgmt/cilium.yaml
@@ -34,7 +34,7 @@ spec:
             # can produce outer packets of 1392 bytes, exceeding enp3s0 MTU and
             # getting silently dropped. Setting MTU to 1200 (1342-142 headroom)
             # ensures inner packets fit within the VXLAN tunnel.
-            mtu: 1200
+            MTU: 1200
             # Octavia (OpenStack CCM) owns LoadBalancer services on mgmt; the
             # Cilium L2 announcer is not used. Disabling it stops the agent from
             # ARP-announcing any LoadBalancer/external IPs.

--- a/infrastructure/sveltos/clusterprofiles/cilium.yaml
+++ b/infrastructure/sveltos/clusterprofiles/cilium.yaml
@@ -55,7 +55,7 @@ spec:
       # the announcer is sufficient to keep Cilium from racing the CCM for
       # type: LoadBalancer IPs.
       values: |
-        mtu: 1200
+        MTU: 1200
         k8sServiceHost: "{{ .Cluster.spec.controlPlaneEndpoint.host }}"
         k8sServicePort: "{{ .Cluster.spec.controlPlaneEndpoint.port }}"
         kubeProxyReplacement: true


### PR DESCRIPTION
PR #408 used lowercase `mtu` which is silently ignored by the Cilium 1.19 Helm chart. The correct key is `MTU` (uppercase) per the [Cilium Helm Reference](https://docs.cilium.io/en/stable/helm-reference/).

Without this fix, the VXLAN tunnel MTU remains at 1342 (auto-detected from enp3s0) and cross-node TLS still fails.