### PR TITLE
fix(renovate): run daily instead of only Monday mornings

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -30,7 +30,12 @@
   ],
 
   timezone: "Europe/Paris",
-  schedule: ["* 0-6 * * 1"], // Monday early morning, batch the noise
+  // Renovate's natural-language schedule is far more robust than raw cron for
+  // hour-range matching. The workflow cron runs hourly (in UTC, often delayed);
+  // Renovate only opens branches/PRs when the run falls inside this window, and
+  // just extracts deps + exits on runs outside it. Run daily in the early
+  // morning so update PRs surface every day (Europe/Paris).
+  schedule: ["before 7am"], // every day, early morning
 
   // Production GitOps: a human reviews and merges every change.
   automerge: false,


### PR DESCRIPTION
Replace the fragile raw-cron schedule (`* 0-6 * * 1`) with Renovate's natural-language `before 7am`.

The old schedule only opened PRs during the Monday 00:00-06:59 window; every other hourly workflow run just extracted deps and exited without creating a PR (confirmed in run logs). Daily early-morning scheduling surfaces update PRs every day (Europe/Paris).