### PR TITLE
fix(npins): skip frozen pins in update matrix

### DIFF
--- a/.github/workflows/npins-update.yaml
+++ b/.github/workflows/npins-update.yaml
@@ -45,7 +45,9 @@ jobs:
         uses: actions/checkout@v4
       - id: set-pins
         run: |
-          PINS=$(jq -c '.pins | keys' npins/sources.json)
+          # Exclude frozen pins: `npins update <frozen>` ignores them and then
+          # exits 1 with "no valid pin selected for update", failing the job.
+          PINS=$(jq -c '[.pins | to_entries[] | select(.value.frozen != true) | .key]' npins/sources.json)
           echo "pins=$PINS" >> "$GITHUB_OUTPUT"
   npins-update:
     needs: get-pins


### PR DESCRIPTION
The `get-pins` step listed every pin via `.pins | keys`, including frozen ones (e.g. `sveltosctl`). `npins update <frozen>` ignores the pin and exits 1 with "no valid pin selected for update", failing the matrix job (see failing runs). This filters frozen pins out of the matrix.