### PR TITLE
fix(network): size tenant MTU to the measured 1284, add node remediation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -833,7 +833,7 @@ cilium`** so the CNI is fully installed before Flux — Flux's pods (and the
   Kustomization uses a single `$patch: delete` targeting that label to strip
   them, yielding a core-only install. A templated `sveltos-core-values`
   ConfigMap provides per-cluster values (`kubernetesClusterDomain:
-  <cluster-name>.local`, `managementCluster: true`) via a values swap patch.
+<cluster-name>.local`, `managementCluster: true`) via a values swap patch.
   The new cluster's own ClusterProfiles are re-pushed as raw manifests by the
   `capi-management-sveltos-profiles` ConfigMap. This is consistent with how
   other profiles (openstack-ccm, cinder-csi, external-snapshotter) push Flux
@@ -1159,7 +1159,9 @@ and the `-vN` immutability/rotation workflow.
 - `clusterclass.yaml` - ClusterClass `openstack-default` (renamed from `openstack-mgmt`) with variables: identityRef, externalNetworkId, managedSubnetCIDR, managedSubnetAllocationPools, imageName, controlPlaneFlavor, workerFlavor, sshKeyName, apiServerFloatingIP, **oidc**. Template refs use the versioned `openstack-default-*-v1` names, except `infrastructure.templateRef` which now points at `openstack-default-cluster-v3` (no redundant Cilium rules). The **`oidc`** object variable (`enabled`/`issuerURL`/`clientID`/`usernameClaim`/`usernamePrefix`/`groupsClaim`/`groupsPrefix`) is an `enabledIf` patch that appends the `--oidc-*` kube-apiserver `extraArgs` (issuer-url, client-id, username-claim, username-prefix, groups-claim, groups-prefix) onto the control-plane `KubeadmControlPlaneTemplate`. It targets the shared Zitadel **`kubernetes`** OIDC client (a public/native PKCE app with **no client secret** — see `clusters/openstack/crossplane/zitadel/oidc-apps.yaml`); the apiserver only validates ID tokens so no secret is plumbed to mgmt. The Zitadel-generated `clientID` must be copied by hand into the `Cluster` CR's `oidc.clientID` and `enabled` flipped to true (don't enable with an empty clientID; enabling rolls the control-plane machines). **Group mapping**: the shared Zitadel `groupsClaim` Action (`clusters/openstack/crossplane/zitadel/actions.yaml`) injects each user's granted project role keys into the token's `groups` claim as **bare names** (`kube-admin`/`kube-user`, no prefix), so the ClusterClass defaults `usernamePrefix`/`groupsPrefix` to **empty**. The RBAC bindings for those bare groups live at `clusters/mgmt/apps/kubernetes-rbac/` (`kube-admin` → `cluster-admin`, `kube-user` → `view`), mirroring the bealv reference (`gitops/apps/kubernetes/crb.yaml`). A non-empty `groupsPrefix` would require renaming the binding subjects to `<prefix>kube-admin`.
 - `clusterclass-v1.yaml` - ClusterClass `openstack-default-v1` — legacy class for clusters originally created from `openstack-default-cluster-v2` (which includes the remoteManagedGroups Cilium rules). CAPO's admission webhook makes `OpenStackCluster.spec` immutable after creation, so changing the `infrastructure.templateRef` on a live cluster creates an unreconcilable topology diff (the CAPI topology controller tries to remove the rules, CAPO blocks the spec modification). This class preserves the `-v2` templateRef for existing clusters (e.g. `mgmt`). New clusters should use `openstack-default` (which points at `-v3` and avoids the `409 SecurityGroupRuleExists`). Identical to `openstack-default` in variables/patches; only the `infrastructure.templateRef` differs.
 - `templates/controlplane.yaml` - KubeadmControlPlaneTemplate `openstack-default-control-plane-v1`
+- `templates/controlplane-v2.yaml` - KubeadmControlPlaneTemplate `openstack-default-control-plane-v2` (referenced by `openstack-default`). Adds kubelet `--kube-reserved`/`--system-reserved`/`--eviction-hard`/`--eviction-soft`/image-GC flags on both init and join, plus kube-controller-manager `node-monitor-grace-period=40s`/`node-monitor-period=5s`. See the "Node resilience" note in Section 8.
 - `templates/bootstrap.yaml` - KubeadmConfigTemplate `openstack-default-worker-v1`
+- `templates/bootstrap-v2.yaml` - KubeadmConfigTemplate `openstack-default-worker-v2` (referenced by `openstack-default` and `openstack-kamaji`). Same kubelet reservation/eviction flags as the control-plane `-v2`.
 - `templates/infracluster.yaml` - OpenStackClusterTemplate `openstack-default-cluster-v1`, `-v2` **and** `-v3` (ClusterClass points `infrastructure.templateRef` at `-v3`). The `managedSecurityGroups` sets `allowAllInClusterTraffic: true` (opens ALL node-to-node traffic on every port/protocol, which already covers the Cilium overlay) plus **only** rules scoped to `0.0.0.0/0`: SSH ingress, DNS egress, and (since `-v2`) the Kubernetes NodePort range (TCP 30000–32767) — REQUIRED for external `type: LoadBalancer` Services via the OpenStack CCM + Octavia (the Octavia/OVN VIP DNATs to `<node IP>:<nodePort>`; without this rule the managed SG drops it and the LB floating IP times out at the TCP layer despite correct VIP/floating-IP/DNS). **`-v3` REMOVES the explicit `remoteManagedGroups: [controlplane, worker]` Cilium data-plane rules (VXLAN UDP 8472 / health TCP 4240 / Hubble TCP 4244 / ICMP)** that `-v1`/`-v2` carried: because `allowAllInClusterTraffic` already opens all traffic between the managed groups, each of those rules normalizes to a Neutron rule tuple CAPO also creates, so on a fresh cluster the second POST returns `409 SecurityGroupRuleExists` and aborts the whole SG reconcile (wedged new cluster `testb`). They were labelled "redundant but harmless" — they are redundant AND harmful (a duplicate rule is a hard 409, not a no-op). `-v1`/`-v2` are retained only until the rotation to `-v3` is confirmed, then deleted (per the README `-vN` workflow — an `OpenStackClusterTemplate` rotation reconciles the SGs onto the live `OpenStackCluster` without rolling machines). `identityRef` is hardcoded to `mgmt-cloud-config` (CAPO requires it at admission time); the ClusterClass `identityRef` variable/patch overrides this default per-cluster when the topology controller synthesizes the concrete `OpenStackCluster`.
 - `templates/machines.yaml` - OpenStackMachineTemplate `openstack-default-control-plane-v1` and `openstack-default-worker-v1` (flavor/image are `dummy` placeholders overwritten by patches)
 - `namespace.yaml` - Namespace `mgmt`
@@ -2343,13 +2345,112 @@ Once all VMs are off and every node is back `Updated/Success/Enabled`, confirm
 `nova-compute` services are `up` (nova `os-services`) and no VMs remain on the
 drained host (`servers/detail?all_tenants=1&host=<node>`).
 
-#### Tenant network MTU is pinned to 1400 (no jumbo frames)
+#### Node resilience: MachineHealthCheck + kubelet reservations
 
-`infrastructure/yaook/neutron.yaml` pins the tenant/provider network MTU to
-**1400** (`DEFAULT.global_physnet_mtu: 1400`, `ml2.path_mtu: 1400`,
-`ml2.physical_network_mtus: enp3s0:1400`). Combined with `advertise_mtu: True`,
-Neutron advertises the derived overlay MTU (OVN geneve = 38B overhead →
-~**1362**) to tenant VMs over DHCP.
+**2026-07-26.** Two gaps made a single sick node escalate into a cluster-wide
+incident (worker `mgmt-md-0-285vl-xqztp-jz5cb` went `Ready=Unknown` with
+"Kubelet stopped posting node status" and stayed that way):
+
+1. **There was NO `MachineHealthCheck` anywhere in the repo**, so an unreachable
+   node was never remediated. Deployment Pods taint-evict and reschedule, but
+   every **StatefulSet** Pod on the node stays stuck `Terminating` FOREVER — a
+   StatefulSet cannot create a replacement while the old Pod is
+   unreachable-but-not-deleted (at-most-one semantics). Prometheus, the Mimir
+   ingester, Vault and kamaji-etcd were all wedged this way, and 48 Pods total
+   were stranded. Deleting the Machine is the only action that removes the Node
+   object and releases them. All four ClusterClasses now define `healthCheck`
+   (workers: remediate after 300s, `unhealthyLessThanOrEqualTo: 40%`,
+   `maxInFlight: 1`; kubeadm control planes: 600s and
+   `unhealthyLessThanOrEqualTo: 1`). NOTE `maxInFlight` is **workers-only** in
+   the ClusterClass schema — the API rejects it under `controlPlane`.
+   `healthCheck` is a ClusterClass field, not part of the immutable templates,
+   so adding it to the legacy `-v1` classes does **not** roll their Machines.
+2. **The kubelet ran with upstream defaults**: no `--kube-reserved` /
+   `--system-reserved` (so Allocatable == Capacity and Pods may commit 100% of
+   the node), and the default `--eviction-hard=memory.available<100Mi` which is
+   far too tight to beat the kernel OOM killer. Observed memory-LIMIT overcommit
+   on the 4 vCPU / 8 GiB workers was **209%**. The `-v2` templates set
+   reservations and wider eviction thresholds; since
+   `--enforce-node-allocatable` defaults to `pods`, this genuinely caps the
+   `kubepods` cgroup so Pods OOM inside their own cgroup instead of taking the
+   kubelet down with them.
+
+Contributing factor worth watching: the VMs are packed unevenly across
+hypervisors — `lucy` was at **load average 41** on 12 cores (6 VMs) and `quinn`
+at 32 on 8 cores (5 VMs), while `makise` sat at load 2.5 with **zero** VMs. Nova
+does not rebalance existing instances, so this is historical placement, not a
+live scheduler bug; new/replaced VMs should land on `makise`. Do **not** "fix"
+it by editing `compute.configTemplates[].novaComputeConfig` — that makes the
+operator flag every `NovaComputeNode` `RequiresRecreation` and start a rolling
+eviction, which is broken on this cluster (see the nova cold-migration note).
+
+#### Tenant MTU: `path_mtu` is 1342 so VMs get 1284 (measured, do NOT raise)
+
+**2026-07-26.** `ml2.path_mtu` is **1342**, giving tenant VMs `1342 − 58` =
+**1284**. It was previously 1400 (→ VMs got 1342), which was **58 bytes too big
+for the north-south path** and was the true cause of the recurring
+`net/http: TLS handshake timeout` on image pulls and the long-standing "flaky
+etcd / works after a retry" symptoms.
+
+Neutron derives a geneve network's MTU as
+`min(global_physnet_mtu, path_mtu) − 58`, so **`path_mtu` — not
+`global_physnet_mtu` — is the knob that sets the tenant VM MTU.**
+
+Measured with DF pings (`ping -M do -s <payload>`, totalIP = payload+28):
+
+| path                                         | largest totalIP that passes |
+| -------------------------------------------- | --------------------------- |
+| underlay, hypervisor↔hypervisor (eno1.4000) | **1400** OK                 |
+| tenant east-west, VM→VM                      | **1342** OK, 1358 drops     |
+| tenant north-south, VM→internet (OVN SNAT)   | **1284** OK, 1292 drops     |
+
+East-west at 1342 is correct (1342 + 58 geneve = 1400 = the vSwitch limit,
+exactly). But north-south crosses the OVN distributed gateway port, and with
+`ovn_emit_need_to_frag: True` OVN reserves a further tunnel header there,
+enforcing 1284. So Neutron **advertised 1342 while the router enforced 1284**.
+
+TCP then depended entirely on PMTUD, which fails silently wherever ICMP
+frag-needed is filtered. Measured from a mgmt worker, IPv4, 10 TLS handshakes:
+
+```
+registry.k8s.io   ok=10 fail=0    (ICMP honoured; PMTU cache learned 1284)
+ghcr.io           ok=10 fail=0    (ICMP honoured; PMTU cache learned 1284)
+xpkg.upbound.io   ok=0  fail=10   (ICMP filtered -> HARD BLACK HOLE)
+```
+
+The same 10 handshakes from the **hypervisor** host netns (MTU 1500, no geneve)
+were `ok=10 fail=0`, proving the internet path is healthy and the loss is purely
+the tenant-MTU overshoot. A TLS ServerHello+Certificate is several full-MSS
+segments, so it is the first thing to hit the black hole while the tiny SYN/ACK
+sail through.
+
+Diagnostic tells, in order of usefulness:
+
+- `ip -4 route show cache` on a VM showing `mtu 1284` on external destinations
+  while `ip link` says the NIC is 1342 — the kernel is silently papering over
+  the misconfiguration, one stall per new destination IP.
+- A DF ping that fails with **no ICMP and no local error** (pure `100% packet
+loss`) is a REMOTE silent drop. If it fails with `sendmsg: Message too long`
+  that is a LOCAL EMSGSIZE, i.e. just the NIC/route MTU — a different problem.
+
+**This is NOT a vSwitch problem and NOT a Cilium problem:**
+
+- hephaestus `nixosModules/vlanConfiguration.nix` keeps `eno1.4000` at **1400**,
+  which is correct per Hetzner's vSwitch docs and confirmed by the DF sweep
+  above. Do not lower it.
+- Cilium is not in this path: the probe ran in the VM's **root** netns to a
+  non-pod-CIDR destination, so `cilium_vxlan` never sees it, and a Cilium
+  BPF/PMTUD cap surfaces as a local error or ICMP rather than a silent drop.
+  Cilium's own `MTU: 1200` is a separate, independent reservation (1200 + 50
+  vxlan = 1250 < 1284, so it still fits and needs no change).
+
+**Rollout:** Neutron fixes a port's MTU at CREATION time. Existing VMs keep 1342
+until their ports are recreated (roll the machines via CAPI). Stopgap on a
+running VM: `ip link set dev enp3s0 mtu 1284`.
+
+---
+
+Historical context (why 1400 rather than jumbo) follows.
 
 Why 1400 and not jumbo (9000): the underlay is not jumbo-clean end to end. On
 the hephaestus hosts the Hetzner vSwitch VLAN `eno1.4000` is capped at 1400 and
@@ -2467,7 +2568,7 @@ All configuration is declarative, version-controlled, and enables auditable infr
 
 ---
 
-**Last Updated**: July 22, 2026 (Grafana Operator & DaaS transition: added Grafana Operator v5 (`infrastructure/grafana-operator`, `clusters/mgmt/grafana-operator.yaml`) watching all namespaces, migrated Grafana instance to `Grafana` CR (v1beta1) in `infrastructure/grafana/grafana.yaml` preserving Zitadel OIDC & 2Gi PVC, added `GrafanaDatasource` for Mimir, updated HTTPRoute to `grafana-service:3000`, and enabled `allowCrossNamespaceImport: true` for cross-namespace DaaS.)
+**Last Updated**: July 26, 2026 (Networking + node resilience: fixed the tenant MTU black hole — `ml2.path_mtu` 1400 → 1342 in `infrastructure/yaook/neutron.yaml` so tenant VMs get 1284 instead of an unusable 1342, measured with DF sweeps (underlay 1400 OK, east-west 1342 OK, north-south capped at 1284 by the OVN gateway); added the repo's first `MachineHealthCheck`s to all four ClusterClasses so unreachable nodes are remediated instead of stranding StatefulSet Pods; added `openstack-default-control-plane-v2` / `openstack-default-worker-v2` templates with kubelet `--kube-reserved`/`--system-reserved`/eviction thresholds.)
 **Repository**: <https://github.com/RPCU/argus.git>
 **Main Branch**: main
 **Clusters**: OpenStack, mgmt (Cluster API management)

--- a/infrastructure/cluster-api-templates/clusterclass-kamaji-v1.yaml
+++ b/infrastructure/cluster-api-templates/clusterclass-kamaji-v1.yaml
@@ -51,6 +51,25 @@ spec:
             apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
             kind: OpenStackMachineTemplate
             name: openstack-default-worker-v1
+        # Legacy class: the bootstrap templateRef intentionally stays at -v1 so
+        # clusters created from it are not rolled. `healthCheck` is a
+        # ClusterClass field (not part of the immutable template), so adding it
+        # is safe and does NOT roll any Machine. See clusterclass.yaml for the
+        # full rationale.
+        healthCheck:
+          checks:
+            nodeStartupTimeoutSeconds: 1200
+            unhealthyNodeConditions:
+              - type: Ready
+                status: Unknown
+                timeoutSeconds: 300
+              - type: Ready
+                status: "False"
+                timeoutSeconds: 300
+          remediation:
+            maxInFlight: 1
+            triggerIf:
+              unhealthyLessThanOrEqualTo: 40%
 
   # ---------------------------------------------------------------------------
   # Variables — identical to openstack-kamaji

--- a/infrastructure/cluster-api-templates/clusterclass-kamaji.yaml
+++ b/infrastructure/cluster-api-templates/clusterclass-kamaji.yaml
@@ -48,12 +48,35 @@ spec:
           templateRef:
             apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
             kind: KubeadmConfigTemplate
-            name: openstack-default-worker-v1
+            name: openstack-default-worker-v2
         infrastructure:
           templateRef:
             apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
             kind: OpenStackMachineTemplate
             name: openstack-default-worker-v1
+        # See clusterclass.yaml for the full rationale: without a
+        # MachineHealthCheck an unreachable node is never remediated, and every
+        # StatefulSet Pod on it stays stuck Terminating indefinitely.
+        #
+        # This matters MORE on Kamaji clusters than on kubeadm ones: the
+        # control plane lives as Pods on the management cluster, so a dead
+        # worker never affects the API server and the failure is easy to miss.
+        # There is deliberately no control-plane healthCheck here — a
+        # KamajiControlPlane is not Machine-based, so CAPI cannot remediate it.
+        healthCheck:
+          checks:
+            nodeStartupTimeoutSeconds: 1200
+            unhealthyNodeConditions:
+              - type: Ready
+                status: Unknown
+                timeoutSeconds: 300
+              - type: Ready
+                status: "False"
+                timeoutSeconds: 300
+          remediation:
+            maxInFlight: 1
+            triggerIf:
+              unhealthyLessThanOrEqualTo: 40%
 
   # ---------------------------------------------------------------------------
   # Variables

--- a/infrastructure/cluster-api-templates/clusterclass-v1.yaml
+++ b/infrastructure/cluster-api-templates/clusterclass-v1.yaml
@@ -25,6 +25,27 @@ spec:
       apiVersion: controlplane.cluster.x-k8s.io/v1beta2
       kind: KubeadmControlPlaneTemplate
       name: openstack-default-control-plane-v1
+    # NOTE: the control-plane templateRef stays at -v1 on purpose. This legacy
+    # class exists precisely to avoid rolling clusters created from it; the
+    # kubelet-hardening flags live in the -v2 templates used by
+    # `openstack-default`. `healthCheck` below, by contrast, is a ClusterClass
+    # field rather than part of the immutable template, so adding it here is
+    # safe and does NOT roll any Machine.
+    healthCheck:
+      checks:
+        nodeStartupTimeoutSeconds: 1200
+        unhealthyNodeConditions:
+          - type: Ready
+            status: Unknown
+            timeoutSeconds: 600
+          - type: Ready
+            status: "False"
+            timeoutSeconds: 600
+      remediation:
+        # `maxInFlight` is workers-only in the ClusterClass schema; the API
+        # rejects it under controlPlane. See clusterclass.yaml.
+        triggerIf:
+          unhealthyLessThanOrEqualTo: 1
     machineInfrastructure:
       templateRef:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
@@ -56,6 +77,23 @@ spec:
             apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
             kind: OpenStackMachineTemplate
             name: openstack-default-worker-v1
+        # See clusterclass.yaml for the full rationale: without a
+        # MachineHealthCheck an unreachable node is never remediated, and every
+        # StatefulSet Pod on it stays stuck Terminating indefinitely.
+        healthCheck:
+          checks:
+            nodeStartupTimeoutSeconds: 1200
+            unhealthyNodeConditions:
+              - type: Ready
+                status: Unknown
+                timeoutSeconds: 300
+              - type: Ready
+                status: "False"
+                timeoutSeconds: 300
+          remediation:
+            maxInFlight: 1
+            triggerIf:
+              unhealthyLessThanOrEqualTo: 40%
 
   # ---------------------------------------------------------------------------
   # Variables — identical to openstack-default

--- a/infrastructure/cluster-api-templates/clusterclass.yaml
+++ b/infrastructure/cluster-api-templates/clusterclass.yaml
@@ -23,12 +23,41 @@ spec:
     templateRef:
       apiVersion: controlplane.cluster.x-k8s.io/v1beta2
       kind: KubeadmControlPlaneTemplate
-      name: openstack-default-control-plane-v1
+      name: openstack-default-control-plane-v2
     machineInfrastructure:
       templateRef:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: OpenStackMachineTemplate
         name: openstack-default-control-plane-v1
+    # -------------------------------------------------------------------------
+    # Control-plane MachineHealthCheck — see the worker healthCheck below for
+    # the full rationale. Deliberately MORE conservative than the worker one:
+    # remediating a control-plane Machine deletes an etcd member, so it only
+    # fires when EXACTLY ONE control-plane Machine is unhealthy. If two or more
+    # are unhealthy the cluster is having a systemic problem (e.g. a hypervisor
+    # outage) and automated deletion would make it strictly worse.
+    # -------------------------------------------------------------------------
+    healthCheck:
+      checks:
+        # Generous: an OpenStack VM boot + kubeadm join on a busy hypervisor has
+        # been observed to take >10 min. Too low here causes remediation loops
+        # that never let a node finish joining.
+        nodeStartupTimeoutSeconds: 1200
+        unhealthyNodeConditions:
+          # Unknown == "kubelet stopped posting node status", the exact
+          # signature of the 2026-07-25 incident.
+          - type: Ready
+            status: Unknown
+            timeoutSeconds: 600
+          - type: Ready
+            status: "False"
+            timeoutSeconds: 600
+      remediation:
+        # NOTE: `maxInFlight` is NOT part of the control-plane remediation
+        # schema (workers only) — the API rejects it here. Concurrency is
+        # already bounded by `unhealthyLessThanOrEqualTo: 1` below.
+        triggerIf:
+          unhealthyLessThanOrEqualTo: 1
 
   # ---------------------------------------------------------------------------
   # Cluster infrastructure
@@ -49,12 +78,53 @@ spec:
           templateRef:
             apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
             kind: KubeadmConfigTemplate
-            name: openstack-default-worker-v1
+            name: openstack-default-worker-v2
         infrastructure:
           templateRef:
             apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
             kind: OpenStackMachineTemplate
             name: openstack-default-worker-v1
+        # ---------------------------------------------------------------------
+        # Worker MachineHealthCheck.
+        #
+        # WHY (2026-07-25 incident): this repo previously defined NO
+        # MachineHealthCheck anywhere, so an unreachable node was never
+        # remediated — it simply sat `Ready=Unknown` indefinitely. That is much
+        # worse than it sounds:
+        #
+        #   * Deployment Pods get taint-evicted and reschedule, but every
+        #     StatefulSet Pod on the node stays stuck `Terminating` FOREVER.
+        #     A StatefulSet will not create a replacement while the old Pod is
+        #     unreachable-but-not-deleted (it cannot prove the old one is gone,
+        #     and at-most-one semantics forbid a second copy). Prometheus,
+        #     Mimir ingester, Vault and kamaji-etcd were all wedged this way.
+        #   * The node's ClusterIP endpoints keep pointing at dead Pod IPs until
+        #     the endpoint controller catches up, producing the misleading
+        #     "connect: no route to host" / "TLS handshake timeout" errors that
+        #     look like a CNI/MTU problem but are not.
+        #
+        # Deleting the Machine is the ONLY action that removes the Node object,
+        # which is what finally releases those Pods. Hence: remediate.
+        #
+        # `unhealthyLessThanOrEqualTo: 40%` is the blast-radius guard — if more
+        # than 40% of the workers are unhealthy at once the cause is systemic
+        # (hypervisor down, network partition) and mass-deleting Machines would
+        # amplify the outage, so remediation is suppressed and a human decides.
+        # ---------------------------------------------------------------------
+        healthCheck:
+          checks:
+            nodeStartupTimeoutSeconds: 1200
+            unhealthyNodeConditions:
+              - type: Ready
+                status: Unknown
+                timeoutSeconds: 300
+              - type: Ready
+                status: "False"
+                timeoutSeconds: 300
+          remediation:
+            maxInFlight: 1
+            triggerIf:
+              unhealthyLessThanOrEqualTo: 40%
 
   # ---------------------------------------------------------------------------
   # Variables — the knobs a Cluster CR sets to customise a deployment.

--- a/infrastructure/cluster-api-templates/kustomization.yaml
+++ b/infrastructure/cluster-api-templates/kustomization.yaml
@@ -5,10 +5,12 @@ resources:
   - clusterclass-kamaji.yaml
   - clusterclass-kamaji-v1.yaml
   - templates/controlplane.yaml
+  - templates/controlplane-v2.yaml
   - templates/controlplane-kamaji.yaml
   - templates/controlplane-kamaji-v2.yaml
   - templates/controlplane-kamaji-v3.yaml
   - templates/bootstrap.yaml
+  - templates/bootstrap-v2.yaml
   - templates/infracluster.yaml
   - templates/machines.yaml
   - templates/infrakamaji.yaml

--- a/infrastructure/cluster-api-templates/templates/bootstrap-v2.yaml
+++ b/infrastructure/cluster-api-templates/templates/bootstrap-v2.yaml
@@ -1,0 +1,75 @@
+# -----------------------------------------------------------------------------
+# Worker bootstrap template (KubeadmConfig) — v2.
+#
+# WHAT CHANGED vs -v1: node-stability kubelet flags (resource reservations,
+# eviction thresholds, image GC). See the rationale block below.
+#
+# IMMUTABILITY: like the control-plane template, the spec is immutable once a
+# ClusterClass references it. To change it, create a new -v3 and repoint the
+# matching machineDeployment class in clusterclass.yaml. The topology controller
+# will roll the affected MachineDeployment.
+#
+# -----------------------------------------------------------------------------
+# WHY THESE FLAGS EXIST (2026-07-25 incident)
+# -----------------------------------------------------------------------------
+# Worker `mgmt-md-0-285vl-xqztp-jz5cb` went NotReady with "Kubelet stopped
+# posting node status", then hard-rebooted, then took >10 min to bring
+# containerd up. Root cause was resource starvation, and -v1 ran the kubelet
+# with UPSTREAM DEFAULTS, i.e.:
+#
+#   * `--kube-reserved` / `--system-reserved` UNSET → node Allocatable ==
+#     node Capacity. The scheduler is therefore free to commit 100% of the
+#     node's CPU/RAM to Pods, leaving nothing for the kubelet, containerd,
+#     systemd and sshd themselves. On these 4 vCPU / 8 GiB workers the observed
+#     memory-LIMIT overcommit was 209%, so a burst past requests starves the
+#     kubelet — which is exactly "kubelet stopped posting node status".
+#   * `--eviction-hard` defaults to `memory.available<100Mi`, far too tight to
+#     react in time: by the time only 100 MiB is left the kernel OOM killer
+#     (or livelock) usually wins the race against the kubelet's eviction loop.
+#
+# Because `--enforce-node-allocatable` defaults to `pods`, setting the two
+# reservation flags is not merely scheduler bookkeeping — the kubelet caps the
+# `kubepods` cgroup at (capacity - kube-reserved - system-reserved -
+# eviction-hard). Pods then OOM inside their own cgroup instead of taking the
+# node's control processes down with them. That is the durable fix.
+#
+# Sizing note: values are deliberately absolute (not percentages) and tuned for
+# the smallest flavor in use (`large` = 4 vCPU / 8 GiB). They cost ~400m CPU
+# and ~1.5 GiB of Allocatable on such a node, which is the intended trade:
+# slightly less schedulable capacity in exchange for a node that stays
+# reachable and remediable under pressure.
+# -----------------------------------------------------------------------------
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
+kind: KubeadmConfigTemplate
+metadata:
+  name: openstack-default-worker-v2
+  namespace: mgmt
+spec:
+  template:
+    spec:
+      joinConfiguration:
+        nodeRegistration:
+          kubeletExtraArgs:
+            - name: provider-id
+              value: openstack:///'{{ instance_id }}'
+            # Carve out capacity for the kubelet/CRI and for the OS.
+            - name: kube-reserved
+              value: cpu=200m,memory=768Mi,ephemeral-storage=2Gi
+            - name: system-reserved
+              value: cpu=200m,memory=768Mi,ephemeral-storage=2Gi
+            # React well before the kernel OOM killer does.
+            - name: eviction-hard
+              value: memory.available<500Mi,nodefs.available<10%,imagefs.available<10%,nodefs.inodesFree<5%
+            - name: eviction-soft
+              value: memory.available<1Gi,nodefs.available<15%,imagefs.available<15%
+            - name: eviction-soft-grace-period
+              value: memory.available=2m,nodefs.available=2m,imagefs.available=2m
+            - name: eviction-max-pod-grace-period
+              value: "60"
+            # The `large` flavor only has a 50Gi root disk; reclaim images
+            # earlier than the 85%/80% defaults so DiskPressure is rare.
+            - name: image-gc-high-threshold
+              value: "80"
+            - name: image-gc-low-threshold
+              value: "65"
+          name: "{{ local_hostname }}"

--- a/infrastructure/cluster-api-templates/templates/controlplane-v2.yaml
+++ b/infrastructure/cluster-api-templates/templates/controlplane-v2.yaml
@@ -1,0 +1,93 @@
+# -----------------------------------------------------------------------------
+# Control plane template (KubeadmControlPlane) — v2.
+#
+# WHAT CHANGED vs -v1:
+#   1. Node-stability kubelet flags on both init and join node registration —
+#      identical rationale to templates/bootstrap-v2.yaml, read that header for
+#      the full 2026-07-25 incident write-up. In short: -v1 left
+#      `--kube-reserved`/`--system-reserved` unset (Allocatable == Capacity, so
+#      Pods can starve the kubelet) and relied on the far-too-tight
+#      `memory.available<100Mi` default eviction threshold.
+#   2. kube-controller-manager node lifecycle timers made explicit and tightened
+#      (`node-monitor-grace-period=40s`), so an unreachable node is marked
+#      NotReady promptly and the MachineHealthCheck (see clusterclass.yaml
+#      `healthCheck`) starts its remediation countdown sooner. With the defaults
+#      a dead node lingered long enough that every StatefulSet Pod on it
+#      (Prometheus, Mimir, Vault, kamaji-etcd) stayed stuck Terminating — a
+#      StatefulSet will not create a replacement while the old Pod is
+#      unreachable-but-not-deleted.
+#
+# IMMUTABILITY: KubeadmControlPlaneTemplate.spec.template.spec is effectively
+# immutable once referenced by a running ClusterClass. To change anything here,
+# create a NEW template with a bumped version suffix (e.g. -v3), point the
+# ClusterClass controlPlane.templateRef at it, and let the topology controller
+# roll the control-plane machines. Never edit -v2 in place on a live cluster.
+# -----------------------------------------------------------------------------
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+kind: KubeadmControlPlaneTemplate
+metadata:
+  name: openstack-default-control-plane-v2
+  namespace: mgmt
+spec:
+  template:
+    spec:
+      kubeadmConfigSpec:
+        clusterConfiguration:
+          apiServer:
+            extraArgs:
+              - name: kubelet-preferred-address-types
+                value: "InternalIP,Hostname,ExternalIP"
+          controllerManager:
+            extraArgs:
+              # Mark an unreachable Node NotReady quickly so the CAPI
+              # MachineHealthCheck can start remediating it.
+              - name: node-monitor-grace-period
+                value: 40s
+              - name: node-monitor-period
+                value: 5s
+        initConfiguration:
+          skipPhases:
+            - addon/kube-proxy
+          nodeRegistration:
+            kubeletExtraArgs:
+              - name: provider-id
+                value: openstack:///'{{ instance_id }}'
+              - name: kube-reserved
+                value: cpu=200m,memory=768Mi,ephemeral-storage=2Gi
+              - name: system-reserved
+                value: cpu=200m,memory=768Mi,ephemeral-storage=2Gi
+              - name: eviction-hard
+                value: memory.available<500Mi,nodefs.available<10%,imagefs.available<10%,nodefs.inodesFree<5%
+              - name: eviction-soft
+                value: memory.available<1Gi,nodefs.available<15%,imagefs.available<15%
+              - name: eviction-soft-grace-period
+                value: memory.available=2m,nodefs.available=2m,imagefs.available=2m
+              - name: eviction-max-pod-grace-period
+                value: "60"
+              - name: image-gc-high-threshold
+                value: "80"
+              - name: image-gc-low-threshold
+                value: "65"
+            name: "{{ local_hostname }}"
+        joinConfiguration:
+          nodeRegistration:
+            kubeletExtraArgs:
+              - name: provider-id
+                value: openstack:///'{{ instance_id }}'
+              - name: kube-reserved
+                value: cpu=200m,memory=768Mi,ephemeral-storage=2Gi
+              - name: system-reserved
+                value: cpu=200m,memory=768Mi,ephemeral-storage=2Gi
+              - name: eviction-hard
+                value: memory.available<500Mi,nodefs.available<10%,imagefs.available<10%,nodefs.inodesFree<5%
+              - name: eviction-soft
+                value: memory.available<1Gi,nodefs.available<15%,imagefs.available<15%
+              - name: eviction-soft-grace-period
+                value: memory.available=2m,nodefs.available=2m,imagefs.available=2m
+              - name: eviction-max-pod-grace-period
+                value: "60"
+              - name: image-gc-high-threshold
+                value: "80"
+              - name: image-gc-low-threshold
+                value: "65"
+            name: "{{ local_hostname }}"

--- a/infrastructure/yaook/neutron.yaml
+++ b/infrastructure/yaook/neutron.yaml
@@ -55,7 +55,72 @@ spec:
       ovn_emit_need_to_frag: True
   neutronML2Config:
     ml2:
-      path_mtu: 1400
+      # -----------------------------------------------------------------------
+      # TENANT (geneve) MTU — sized from MEASUREMENT, not arithmetic. DO NOT
+      # RAISE back to 1400 without re-running the DF sweep documented below.
+      #
+      # Neutron derives a geneve network's MTU as
+      #     mtu = min(global_physnet_mtu, path_mtu) - 58   # geneve header
+      # so this knob (not global_physnet_mtu) is what tenant VMs receive over
+      # DHCP. With path_mtu 1400 VMs got 1400-58 = 1342.
+      #
+      # WHY 1342 WAS WRONG — measured 2026-07-26 with DF-set pings
+      # (`ping -M do -s <payload>`, totalIP = payload+28):
+      #
+      #   underlay, hypervisor->hypervisor over eno1.4000 (the Hetzner vSwitch):
+      #       totalIP 1400 .......... OK      <- vSwitch really is 1400
+      #   tenant east-west, VM->VM:
+      #       totalIP 1342 .......... OK
+      #       totalIP 1358 .......... DROP    <- matches advertised 1342
+      #   tenant north-south, VM->internet (via the OVN gateway/SNAT):
+      #       totalIP 1284 .......... OK
+      #       totalIP 1292 .......... DROP    <- 58 BYTES LESS THAN ADVERTISED
+      #
+      # East-west is correct at 1342 (1342 + 58 geneve = 1400 = the vSwitch
+      # limit, exactly). But north-south crosses the OVN distributed gateway
+      # port, and with `ovn_emit_need_to_frag: True` (set above) OVN reserves a
+      # further tunnel header on that path, enforcing 1342 - 58 = 1284. So
+      # Neutron ADVERTISED 1342 while the router ENFORCED 1284: every VM
+      # overshot by 58 bytes on every flow leaving the tenant network.
+      #
+      # TCP then depended entirely on PMTUD to recover, which fails silently
+      # wherever ICMP frag-needed is filtered. Measured from a mgmt worker,
+      # IPv4, 10 TLS handshakes each:
+      #     registry.k8s.io   ok=10 fail=0   (ICMP honoured; cache learned 1284)
+      #     ghcr.io           ok=10 fail=0   (ICMP honoured; cache learned 1284)
+      #     xpkg.upbound.io   ok=0  fail=10  (ICMP filtered -> HARD BLACK HOLE)
+      # The same 10 handshakes from the hypervisor host netns (MTU 1500, no
+      # geneve) were ok=10 fail=0, proving the internet path is healthy and the
+      # loss is purely the tenant-MTU overshoot.
+      #
+      # This is the real source of the recurring `net/http: TLS handshake
+      # timeout` on image pulls and the long-standing "flaky etcd / works after
+      # a retry" symptoms: a TLS ServerHello+Certificate is several full-MSS
+      # segments, so it is the first thing to hit the black hole while the tiny
+      # SYN/ACK sail through.
+      #
+      # 1342 here => tenant MTU 1342 - 58 = 1284, matching what the gateway
+      # actually forwards. `enable_tcp_mss_clamping` then clamps MSS off the
+      # correct value too (it previously clamped to 1302 against a real ceiling
+      # of 1244).
+      #
+      # NOT A vSWITCH CHANGE: hephaestus `nixosModules/vlanConfiguration.nix`
+      # keeps eno1.4000 at MTU 1400. That is CORRECT per Hetzner's vSwitch docs
+      # and is confirmed by the DF sweep above — do not lower it.
+      #
+      # ROLLOUT: Neutron fixes a port's MTU at CREATION time, so existing VMs
+      # keep 1342 until their ports are recreated (roll the machines via CAPI).
+      # Stopgap on a running VM: `ip link set dev enp3s0 mtu 1284`.
+      # Cilium is pinned to MTU 1200 in-cluster (1200 + 50 vxlan = 1250 < 1284)
+      # so it needs no change.
+      # -----------------------------------------------------------------------
+      path_mtu: 1342
+      # physnet `public` is a FLAT network on enp3s0 (a 1500-MTU NIC that does
+      # not cross the vSwitch). NOTE: this key is matched by PHYSNET name, and
+      # the physnet is called `public`, not `enp3s0` — so this entry never
+      # matches and the flat net falls back to global_physnet_mtu. Left as-is
+      # (the live `ext` network is already stored at 1342); fixing the name
+      # would silently resize the external network, which is a separate change.
       physical_network_mtus: enp3s0:1400
     ml2_type_flat:
       flat_networks:


### PR DESCRIPTION
## Problem

The recurring `net/http: TLS handshake timeout` on image pulls — and the long-standing "flaky etcd / works after a retry" symptoms — are a **tenant MTU black hole**, not a transient network fault.

Neutron derives a geneve network's MTU as `min(global_physnet_mtu, path_mtu) - 58`, so `ml2.path_mtu: 1400` advertised **1342** to tenant VMs.

## Measurements

DF pings (`ping -M do -s <payload>`, totalIP = payload + 28):

| path | largest totalIP that passes |
| --- | --- |
| underlay, hypervisor↔hypervisor (`eno1.4000`) | **1400** OK |
| tenant east-west, VM→VM | **1342** OK, 1358 drops |
| tenant north-south, VM→internet (OVN SNAT) | **1284** OK, 1292 drops |

East-west at 1342 is correct (1342 + 58 geneve = 1400 = the vSwitch limit, exactly). North-south crosses the OVN distributed gateway port, where `ovn_emit_need_to_frag` reserves a further tunnel header and enforces 1284. **Neutron advertised 1342 while the router enforced 1284**, so every VM overshot by 58 bytes on every flow leaving the tenant network.

TCP then relied entirely on PMTUD, which fails silently wherever ICMP frag-needed is filtered. From a mgmt worker, IPv4, 10 TLS handshakes each:

```
registry.k8s.io   ok=10 fail=0    (ICMP honoured; PMTU cache learned 1284)
ghcr.io           ok=10 fail=0    (ICMP honoured; PMTU cache learned 1284)
xpkg.upbound.io   ok=0  fail=10   (ICMP filtered -> HARD BLACK HOLE)
```

The same handshakes from the **hypervisor** host netns (MTU 1500, no geneve) were `ok=10 fail=0`, proving the internet path is healthy and the loss is purely the tenant-MTU overshoot.

## Fix

`ml2.path_mtu: 1400 -> 1342`, so VMs are told **1284**.

**Not a vSwitch change** — hephaestus keeps `eno1.4000` at 1400, which is correct per [Hetzner's vSwitch docs](https://docs.hetzner.com/robot/dedicated-server/network/vswitch/) and confirmed by the DF sweep above.

**Not a Cilium change** — the probe ran in the VM *root* netns to a non-pod-CIDR destination, so `cilium_vxlan` never sees it; a Cilium BPF/PMTUD cap surfaces as a local error or ICMP, not a silent drop. Cilium's `MTU: 1200` (+50 vxlan = 1250) still fits under 1284 and needs no change.

## Also: node resilience

The same incident had one worker go `Ready=Unknown` ("Kubelet stopped posting node status") and strand **48 Pods**. Two gaps:

1. **No `MachineHealthCheck` existed anywhere in the repo**, so an unreachable node was never remediated. Deployment Pods taint-evict and reschedule, but StatefulSet Pods stay stuck `Terminating` forever (at-most-one semantics) — Prometheus, Mimir ingester, Vault and kamaji-etcd were all wedged. Deleting the Machine is the only action that frees them. Added `healthCheck` to all four ClusterClasses.
   - `maxInFlight` is **workers-only** in the schema; the API rejects it under `controlPlane`.
   - `healthCheck` is a ClusterClass field, not part of the immutable templates, so the legacy `-v1` classes gain it **without rolling their Machines**.
2. **Kubelet ran with upstream defaults**: Allocatable == Capacity and `--eviction-hard=memory.available<100Mi`, against an observed **209% memory-limit overcommit** on the 4 vCPU / 8 GiB workers. Added `openstack-default-{control-plane,worker}-v2` with kube/system reservations and wider eviction thresholds.

## Rollout

Neutron fixes port MTU at **creation** time, so existing VMs keep 1342 until their ports are recreated (roll the machines via CAPI). Stopgap on a running VM: `ip link set dev enp3s0 mtu 1284`.

The `-v2` template rotation rolls the mgmt Machines; the ClusterClass `healthCheck` additions do not.

## Validation

- `kustomize build` clean for `infrastructure/cluster-api-templates` and `infrastructure/yaook`
- `kubectl apply --dry-run=server` against the live mgmt cluster: **0 errors**
- treefmt / prettier clean