### PR TITLE
fix(neutron): tune northbound OVSDB raft timers like southbound

### DIFF
--- a/infrastructure/yaook/neutron.yaml
+++ b/infrastructure/yaook/neutron.yaml
@@ -197,6 +197,24 @@ spec:
   setup:
     ovn:
       northboundOVSDB:
+        # Same tuning as southboundOVSDB below — the OVN defaults (raft election
+        # timer 1s, inactivity probe 5s) are far too aggressive for these
+        # hyperconverged hosts, which routinely sit at load 30-40 because they
+        # run the OpenStack control plane, Ceph AND the tenant VMs.
+        #
+        # 2026-07-26: northbound was the ONLY OVSDB left on the defaults (the
+        # southbound block had already been tuned). It lost RAFT quorum and sat
+        # in a re-election loop — `cluster/status OVN_Northbound` showed
+        # `Status: disconnected from the cluster (election timeout)`,
+        # `Role: candidate`, `Leader: unknown` at term 662, with members having
+        # restarted 4 and 7 times. All three `ovn-northd` pods went 0/1 with
+        # "clustered database server is disconnected from cluster", so no
+        # logical-network change could be compiled into the dataplane.
+        #
+        # A 1s election timer means a single CPU-starvation stall longer than
+        # one second costs a leader election; at load 40 that is constant.
+        inactivityProbeMs: 60000
+        raftElectionTimerMs: 60000
         replicas: 3
         backup:
           schedule: 0 12 * * *


### PR DESCRIPTION
## Problem

The OVN **northbound** OVSDB was the only one still on the OVN defaults (raft election timer **1s**, inactivity probe **5s**). The `southboundOVSDB` block immediately below it had already been tuned to 60s/60s and even carries the comment:

> `# recommended to increase inactivityProbe and raftElectionTimer at scale (default 5s/1s)`

Northbound was simply missed.

## Incident (2026-07-26)

Northbound lost RAFT quorum and sat in a re-election loop:

```
$ ovs-appctl cluster/status OVN_Northbound
Status: disconnected from the cluster (election timeout)
Role:   candidate
Term:   662
Leader: unknown
```

Members had restarted **4** and **7** times. All three `ovn-northd` pods went **0/1**:

```
ovsdb_cs|INFO|ssl:...northbound-ovsdb-0...:6641: clustered database server is
disconnected from cluster; trying another server
```

With northd down, no logical-network change could be compiled into the dataplane.

**Southbound — already tuned — stayed healthy throughout**, which is what isolated the cause.

## Why

A 1s election timer means any CPU-starvation stall longer than one second costs a leader election. These hyperconverged hosts run the OpenStack control plane, Ceph *and* the tenant VMs, and routinely sit at load 30–40 (`lucy` was measured at load 41 on 12 cores), so that is effectively constant.

## Fix

Mirror the southbound values on `northboundOVSDB`:

```yaml
inactivityProbeMs: 60000
raftElectionTimerMs: 60000
```

## Validation

- `kustomize build infrastructure/yaook` clean
- `kubectl apply --dry-run=server`: `neutrondeployment.yaook.cloud/neutron-ovn configured`
- Recovery already confirmed live: after the DB restart the cluster elected a stable leader (term 663) and all 3 `ovn-northd` returned to `1/1`. This change prevents the flap from recurring.