### PR TITLE
fix(neutron): give the OVN control plane resource requests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1271,7 +1271,21 @@ reconciled by the operators above. Deployed by the `yaook` Flux Kustomization
   Ceph copy-on-write clones instead of streaming a full copy through the
   glance API (images must be **raw** format for COW cloning; safe because
   glance/cinder share one Ceph cluster).
-- `neutron.yaml` - NeutronDeployment (networking)
+- `neutron.yaml` - NeutronDeployment (networking). The `setup.ovn` block sets
+  **`resources` on every OVN component** (`northboundOVSDB.ovsdb`/`ssl-terminator`,
+  `southboundOVSDB.ovsdb`/`ssl-terminator`, `southboundOVSDB.ovnRelay.ovn-relay`/
+  `ssl-terminator`, `northd.northd`, and the per-node `controller.*` agents).
+  They previously had `resources: {}` → QoS **BestEffort** → cgroup v2
+  `cpu.weight` of 1, so they lost every scheduling contest against the Ceph OSDs
+  (2 CPU / 5Gi requests) and the tenant qemu processes on these hyperconverged
+  nodes. See "OVN control plane must not be BestEffort" in Section 8 for the
+  2026-07-26 outage this caused. **No CPU limits** anywhere (throttling a
+  single-threaded raft/dataplane process destroys tail latency — same rationale
+  as the Ceph daemons), and **no memory limit on `ovs-vswitchd`** (an OOM-kill
+  there severs the whole node's dataplane). NOTE the CRD exposes **no
+  `priorityClassName`/scheduling knob** for these components, so unlike the Ceph
+  mons/mgr/osd they cannot be marked `system-cluster-critical` declaratively —
+  that half of the fix needs an upstream yaook change.
 - `nova.yaml` - NovaDeployment (compute). libvirt I/O tuning for RBD-backed
   disks: `disk_cachemodes: [network=writeback]` (librbd writeback cache —
   flushed on guest fsync, large guest write-latency win) and
@@ -2455,6 +2469,58 @@ Once all VMs are off and every node is back `Updated/Success/Enabled`, confirm
 `nova-compute` services are `up` (nova `os-services`) and no VMs remain on the
 drained host (`servers/detail?all_tenants=1&host=<node>`).
 
+#### OVN control plane must not be BestEffort (openstack cluster)
+
+**2026-07-26.** Every OVN pod — NB ovsdb, SB ovsdb, the SB relay, `ovn-northd`
+and the per-node `ovn-controller`/`ovs-vswitchd` — shipped with `resources: {}`,
+i.e. QoS **BestEffort**, i.e. cgroup v2 `cpu.weight` of **1** (the minimum). On
+these hyperconverged hosts they therefore lose every scheduling contest against
+the Ceph OSDs (which DO request 2 CPU / 5Gi) and the tenant qemu processes.
+
+With `lucy` at **load average 69 on 12 cores** (69/37/20 over 1/5/15min) this
+collapsed the whole logical network:
+
+1. `ovsdb-server` is single-threaded and latency-critical. Starved, it could not
+   answer even a **local unix-socket** appctl — a manual
+   `ovs-appctl cluster/status OVN_Northbound` hung for **>120s**.
+2. The ovsdb **liveness probe is that exact command**, with a 20s timeout. It
+   failed, so kubelet killed the container.
+3. The rejoining member had to replay ~3.9k uncommitted raft entries
+   (`Log: [285404, 289300]`), costing more CPU, so the probe failed again —
+   a probe-induced death spiral. Restart counts reached nb-2=**12**, sb-2=**21**.
+4. Quorum was never reached: NB sat at `Role: candidate`, `Term: 676`,
+   `Leader: unknown`, peers unheard for **167s**.
+5. With no NB leader, `ovn-northd` could never attach — its log looped
+   `clustered database server is not cluster leader; trying another server`
+   across all three servers — so it failed its own probe and went 0/1.
+   **northd is the visible symptom, never the cause: always check NB raft first
+   with `ovs-appctl -t /run/ovn/ovnnb_db.ctl cluster/status OVN_Northbound`.**
+6. No logical-network change could compile into the dataplane, so Neutron could
+   not bind ports and **new VMs failed to boot** (no vif-plugged event).
+
+**Tuning the raft timers is not sufficient and does not substitute for this.**
+The earlier `raftElectionTimerMs: 60000` fix applied correctly (status showed
+`Election timer: 60000`) yet peers were still unheard for ~3x that window. You
+cannot tune your way out of a process that cannot get scheduled.
+
+Fix: `resources` on every component in `infrastructure/yaook/neutron.yaml`
+`setup.ovn`. **No CPU limits** (CFS throttling of a single-threaded raft or
+dataplane process destroys tail latency — same rationale as the Ceph daemons);
+CPU _requests_ cost nothing on an idle node and only bind under contention,
+which is exactly when OVN must win. Memory limits are ~100x observed RSS as a
+runaway backstop, **except `ovs-vswitchd` which is deliberately left unlimited**
+because an OOM-kill there severs the entire node's dataplane.
+
+**Unfixable declaratively:** the `NeutronDeployment` CRD exposes no
+`priorityClassName`/scheduling field for these components, so they cannot be
+marked `system-cluster-critical` the way the Ceph mons/mgr/osd are. Needs an
+upstream yaook change.
+
+**Rollout caveat:** applying the `controller.*` resources restarts
+`ovs-vswitchd` on every node, which briefly interrupts the dataplane for all
+tenant VMs. The control-plane half (NB/SB/relay/northd) can be applied
+independently and is safe to do first.
+
 #### Node resilience: MachineHealthCheck + kubelet reservations
 
 **2026-07-26.** Two gaps made a single sick node escalate into a cluster-wide
@@ -2678,7 +2744,9 @@ All configuration is declarative, version-controlled, and enables auditable infr
 
 ---
 
-**Last Updated**: July 26, 2026 (Nova: `resume_guests_state_on_host_boot: true` in `infrastructure/yaook/nova.yaml` so instances Nova believes are ACTIVE are restarted automatically after a hypervisor reboot — previously a node reboot left every CAPO-provisioned VM SHUTOFF until manually started. Added `infrastructure/yaook/disruptionbudget.yaml`, the repo's first `YaookDisruptionBudget` (`preventDeletion: true`, match-all), so that edit — and any future `novaComputeConfig` edit — only FLAGS each `NovaComputeNode` `RequiresRecreation` instead of rolling-deleting it into a cold-migration drain that is broken on this cluster. Documented the mechanism from the operator source plus a per-node manual rollout runbook.)
+**Last Updated**: July 26, 2026 (OVN: set `resources` on every component in `infrastructure/yaook/neutron.yaml` `setup.ovn` — NB/SB ovsdb + their ssl-terminators, the SB relay, `northd`, and the per-node `controller.*` agents were ALL QoS BestEffort (`resources: {}`), so on a node at load 69/12-cores they were starved until `ovsdb-server` could not answer a local appctl within the 20s liveness timeout; kubelet then killed them in a loop, NB raft lost quorum (term 676, no leader), `ovn-northd` could never find a leader and flapped 0/1, and Neutron could not bind ports so new VMs failed to boot. No CPU limits anywhere, and no memory limit on `ovs-vswitchd`. The CRD exposes no `priorityClassName`, so the `system-cluster-critical` half of the fix needs an upstream yaook change. See "OVN control plane must not be BestEffort" in Section 8.)
+
+**Previously**: July 26, 2026 (Nova: `resume_guests_state_on_host_boot: true` in `infrastructure/yaook/nova.yaml` so instances Nova believes are ACTIVE are restarted automatically after a hypervisor reboot — previously a node reboot left every CAPO-provisioned VM SHUTOFF until manually started. Added `infrastructure/yaook/disruptionbudget.yaml`, the repo's first `YaookDisruptionBudget` (`preventDeletion: true`, match-all), so that edit — and any future `novaComputeConfig` edit — only FLAGS each `NovaComputeNode` `RequiresRecreation` instead of rolling-deleting it into a cold-migration drain that is broken on this cluster. Documented the mechanism from the operator source plus a per-node manual rollout runbook.)
 
 **Previously**: July 26, 2026 (Networking + node resilience: fixed the tenant MTU black hole — `ml2.path_mtu` 1400 → 1342 in `infrastructure/yaook/neutron.yaml` so tenant VMs get 1284 instead of an unusable 1342, measured with DF sweeps (underlay 1400 OK, east-west 1342 OK, north-south capped at 1284 by the OVN gateway); added the repo's first `MachineHealthCheck`s to all four ClusterClasses so unreachable nodes are remediated instead of stranding StatefulSet Pods; added `openstack-default-control-plane-v2` / `openstack-default-worker-v2` templates with kubelet `--kube-reserved`/`--system-reserved`/eviction thresholds.)
 **Repository**: <https://github.com/RPCU/argus.git>

--- a/infrastructure/yaook/neutron.yaml
+++ b/infrastructure/yaook/neutron.yaml
@@ -196,6 +196,60 @@ spec:
     name: hetzner
   setup:
     ovn:
+      # =========================================================================
+      # RESOURCE REQUESTS — the OVN control plane must NEVER be BestEffort.
+      #
+      # 2026-07-26 outage. Every OVN pod (NB ovsdb, SB ovsdb, relay, northd,
+      # ovn-controller) shipped with `resources: {}` => QoS BestEffort => cgroup
+      # v2 `cpu.weight` of 1, the minimum. On these hyperconverged hosts that
+      # means they lose every scheduling contest against the Ceph OSDs (which
+      # DO request 2 CPU / 5Gi, see rook/configs/cephcluster.yaml) and against
+      # the qemu processes of the tenant VMs.
+      #
+      # lucy was measured at load average 69 on 12 cores (69/37/20 over
+      # 1/5/15min) when this was written. Under that contention:
+      #
+      #   1. `ovsdb-server` (single-threaded, latency-critical) is starved so
+      #      hard it cannot answer even a LOCAL unix-socket appctl — a manual
+      #      `ovs-appctl cluster/status OVN_Northbound` hung for >120s.
+      #   2. The ovsdb liveness probe IS that command, with a 20s timeout. It
+      #      fails, so kubelet kills the container.
+      #   3. The member rejoins and must replay its uncommitted raft log
+      #      (`Log: [285404, 289300]` ~ 3.9k entries), which costs more CPU, so
+      #      the probe fails again. Death spiral.
+      #   4. Quorum is never reached: NB sat at `Role: candidate`, `Term: 676`,
+      #      `Leader: unknown`, peers unheard for 167s. Restart counts were
+      #      nb-2=12, sb-2=21.
+      #   5. With no NB leader, `ovn-northd` can never attach ("clustered
+      #      database server is not cluster leader; trying another server", in a
+      #      loop over all three servers) so it fails ITS probes and goes 0/1 —
+      #      northd was the visible symptom but never the cause.
+      #   6. No logical-network change compiles into the dataplane => Neutron
+      #      cannot bind ports => new VMs never get a vif-plugged event and fail
+      #      to boot.
+      #
+      # NOTE this is why the raftElectionTimerMs tuning below was NOT enough on
+      # its own: the timer was correctly applied (`Election timer: 60000`) yet
+      # peers were still unheard for ~3x that. You cannot tune your way out of a
+      # process that cannot get scheduled.
+      #
+      # NO CPU LIMITS ANYWHERE, deliberately — same rationale as the Ceph
+      # daemons: CFS throttling of a single-threaded raft/dataplane process
+      # destroys tail latency, which is the exact failure we are fixing.
+      # CPU *requests* cost nothing when the node is idle; they only bind under
+      # contention, which is precisely when OVN must win.
+      #
+      # Memory limits are set ~100x observed RSS (northd peaked at 18MB; NB
+      # idl-cells 2751, SB idl-cells 14818) purely as a runaway backstop —
+      # EXCEPT ovs-vswitchd, which is deliberately left unlimited because an
+      # OOM-kill there takes down the whole node's dataplane.
+      #
+      # LIMITATION: the NeutronDeployment CRD exposes no `priorityClassName` /
+      # scheduling knob for these components, so they can NOT be marked
+      # `system-cluster-critical` declaratively the way the Ceph mons/mgr/osd
+      # are. Requests are the only lever available here; the priority-class half
+      # of this fix needs an upstream yaook change.
+      # =========================================================================
       northboundOVSDB:
         # Same tuning as southboundOVSDB below — the OVN defaults (raft election
         # timer 1s, inactivity probe 5s) are far too aggressive for these
@@ -216,11 +270,36 @@ spec:
         inactivityProbeMs: 60000
         raftElectionTimerMs: 60000
         replicas: 3
+        resources:
+          # The raft member itself. Single-threaded, so a 500m request is a real
+          # half-core of weight rather than a token value.
+          ovsdb:
+            requests:
+              cpu: 500m
+              memory: 512Mi
+            limits:
+              memory: 2Gi
+          # In the connection path for EVERY northd/neutron client (TLS is
+          # terminated here, not in ovsdb). Starving this stalls connections
+          # just as effectively as starving ovsdb.
+          ssl-terminator:
+            requests:
+              cpu: 100m
+              memory: 64Mi
+            limits:
+              memory: 256Mi
         backup:
           schedule: 0 12 * * *
       northd:
         # northd remote probe interval (to nb or nb relay) can be adjusted individually
         remoteInactivityProbeMs: 60000
+        resources:
+          northd:
+            requests:
+              cpu: 300m
+              memory: 256Mi
+            limits:
+              memory: 1Gi
       southboundOVSDB:
         # recommended to increase inactivityProbe and raftElectionTimer at scale (default 5s/1s)
         inactivityProbeMs: 60000
@@ -230,12 +309,82 @@ spec:
           inactivityProbeMs: 120000
           remoteInactivityProbeMs: 60000
           replicas: 3
+          resources:
+            # Every ovn-controller in the cloud reads SB THROUGH the relay, so a
+            # starved relay stalls the dataplane on all nodes at once.
+            ovn-relay:
+              requests:
+                cpu: 300m
+                memory: 256Mi
+              limits:
+                memory: 1Gi
+            ssl-terminator:
+              requests:
+                cpu: 100m
+                memory: 64Mi
+              limits:
+                memory: 256Mi
         replicas: 3
+        resources:
+          # SB is the larger of the two DBs (idl-cells 14818 vs NB's 2751) and
+          # is read by every ovn-controller, hence more headroom than NB.
+          ovsdb:
+            requests:
+              cpu: 500m
+              memory: 1Gi
+            limits:
+              memory: 3Gi
+          ssl-terminator:
+            requests:
+              cpu: 100m
+              memory: 64Mi
+            limits:
+              memory: 256Mi
         backup:
           schedule: 0 12 * * *
       controller:
         # ovn-controller remote probe interval (to sb or sb relay) can be adjusted individually
         remoteInactivityProbeMs: 60000
+        # These are the per-node DATAPLANE agents, not strictly "control plane",
+        # but they were BestEffort too and were visibly suffering for it:
+        # neutron-ovn-controller-* had restarted 9-11 times. A starved
+        # ovs-vswitchd does not just flap a probe, it drops packets.
+        resources:
+          # Translates SB logical flows into OpenFlow. Starved => the node's
+          # flows go stale => VMs silently lose connectivity.
+          ovn-controller:
+            requests:
+              cpu: 300m
+              memory: 512Mi
+            limits:
+              memory: 2Gi
+          # NO memory limit on purpose: vswitchd growth scales with port/flow
+          # count, and an OOM-kill here severs the whole node's dataplane
+          # (every tenant VM on it). A request without a limit gives it
+          # scheduling weight while keeping that failure mode impossible.
+          ovs-vswitchd:
+            requests:
+              cpu: 500m
+              memory: 512Mi
+          ovs-vswitchd-monitoring:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              memory: 256Mi
+          # Local (non-raft) conf.db for the node's own OVS instance.
+          ovsdb-server:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              memory: 512Mi
+          neutron-ovn-metadata-agent:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              memory: 1Gi
         configTemplates:
           - nodeSelectors:
               - matchLabels: {}


### PR DESCRIPTION
## Problem

Every OVN pod — NB ovsdb, SB ovsdb, the SB relay, `ovn-northd` and the per-node `ovn-controller`/`ovs-vswitchd` — shipped with `resources: {}`, i.e. QoS **BestEffort**, i.e. cgroup v2 `cpu.weight` of **1**. On these hyperconverged hosts they lose every scheduling contest against the Ceph OSDs (which do request 2 CPU / 5Gi) and the tenant qemu processes.

With `lucy` at **load average 69 on 12 cores** (69/37/20 over 1/5/15min) this collapsed the logical network:

1. `ovsdb-server` is single-threaded and latency-critical. Starved, it could not answer even a **local unix-socket** appctl — `ovs-appctl cluster/status OVN_Northbound` hung for **>120s**.
2. The ovsdb **liveness probe is that exact command**, 20s timeout. It failed, so kubelet killed the container.
3. The rejoining member replayed ~3.9k uncommitted raft entries (`Log: [285404, 289300]`), costing more CPU, so the probe failed again — a probe-induced death spiral. Restart counts reached nb-2=**12**, sb-2=**21**.
4. Quorum was never reached: NB sat at `Role: candidate`, `Term: 676`, `Leader: unknown`, peers unheard for **167s**.
5. With no NB leader `ovn-northd` could never attach, looping `clustered database server is not cluster leader; trying another server` across all three servers, so it failed its own probe and went 0/1. **northd was the visible symptom, never the cause.**
6. No logical-network change could compile into the dataplane → Neutron could not bind ports → **new VMs failed to boot** (no vif-plugged event).

The earlier `raftElectionTimerMs: 60000` tuning (e353649) was necessary but **not sufficient** — it applied correctly (`Election timer: 60000`) yet peers were still unheard for ~3x that window. You cannot tune your way out of a process that cannot get scheduled.

## Change

`resources` on every component in `infrastructure/yaook/neutron.yaml` `setup.ovn`:

| Component | CPU req | Mem req | Mem limit |
|---|---|---|---|
| NB `ovsdb` | 500m | 512Mi | 2Gi |
| SB `ovsdb` | 500m | 1Gi | 3Gi |
| `ovn-relay` | 300m | 256Mi | 1Gi |
| `northd` | 300m | 256Mi | 1Gi |
| `ovn-controller` | 300m | 512Mi | 2Gi |
| `ovs-vswitchd` | 500m | 512Mi | **none** |
| ssl-terminators / misc | 50–100m | 64–256Mi | 256–512Mi |

- **No CPU limits anywhere**, deliberately — CFS throttling of a single-threaded raft/dataplane process destroys tail latency, the exact failure being fixed. CPU *requests* cost nothing on an idle node and only bind under contention, which is precisely when OVN must win.
- **No memory limit on `ovs-vswitchd`** — it grows with flow count and an OOM-kill there severs the whole node's dataplane.

Per-node reservation ~2950m CPU / ~3.6Gi memory: 25% of lucy/makise (12 cores), **37% of quinn (8 cores)**.

## Known gap

The `NeutronDeployment` CRD exposes **no `priorityClassName`/scheduling field**, so unlike the Ceph mons/mgr/osd these cannot be marked `system-cluster-critical` declaratively. Requests are the only lever available; that half needs an upstream yaook change. Documented in AGENTS.md.

## Rollout caveat

Applying the `controller.*` resources **restarts `ovs-vswitchd` on every node**, briefly interrupting the dataplane for all tenant VMs. The control-plane half (NB/SB/relay/northd) is independent and safe to apply first.

## Validation

- `kustomize build infrastructure/yaook/` OK
- `kubectl apply --dry-run=server` → `neutrondeployment.yaook.cloud/neutron-ovn configured`
- Container keys verified against the live CRD schema (they differ from rendered pod container names — schema uses `ssl-terminator`, pods render `ssl-terminator-ovsdb`)
- pre-commit / treefmt clean