### PR TITLE
fix: restore RabbitMQ CPU limits (1000m) with low requests (250m)

### DIFF
--- a/infrastructure/rook/configs/cephcluster.yaml
+++ b/infrastructure/rook/configs/cephcluster.yaml
@@ -28,13 +28,13 @@ spec:
   resources:
     mon:
       requests:
-        cpu: 500m
+        cpu: 300m
         memory: 1Gi
       limits:
         memory: 2Gi
     mgr:
       requests:
-        cpu: 250m
+        cpu: 100m
         memory: 512Mi
       limits:
         memory: 1Gi

--- a/infrastructure/rook/configs/cephfilesystem.yaml
+++ b/infrastructure/rook/configs/cephfilesystem.yaml
@@ -52,7 +52,7 @@ spec:
     priorityClassName: system-cluster-critical
     resources:
       requests:
-        cpu: 500m
+        cpu: 250m
         memory: 2Gi
       limits:
         memory: 4Gi

--- a/infrastructure/rook/configs/cephnfs.yaml
+++ b/infrastructure/rook/configs/cephnfs.yaml
@@ -56,7 +56,7 @@ spec:
     priorityClassName: system-cluster-critical
     resources:
       requests:
-        cpu: 500m
+        cpu: 250m
         memory: 1Gi
       limits:
         memory: 2Gi

--- a/infrastructure/yaook/cinder.yaml
+++ b/infrastructure/yaook/cinder.yaml
@@ -50,7 +50,7 @@ spec:
         resources:
           cinder-volume:
             requests:
-              cpu: 500m
+              cpu: 200m
               memory: 1Gi
             limits:
               memory: 2Gi
@@ -94,7 +94,7 @@ spec:
     resources:
       rabbitmq:
         requests:
-          cpu: 1000m
+          cpu: 250m
           memory: 1G
         limits:
           memory: 2G

--- a/infrastructure/yaook/designate.yaml
+++ b/infrastructure/yaook/designate.yaml
@@ -51,7 +51,7 @@ spec:
     resources:
       rabbitmq:
         limits:
-          cpu: 1000m
+          cpu: 250m
           memory: 1G
     scheduleRuleWhenUnsatisfiable: ScheduleAnyway
     storageSize: 8Gi

--- a/infrastructure/yaook/neutron.yaml
+++ b/infrastructure/yaook/neutron.yaml
@@ -50,7 +50,7 @@ spec:
       rabbitmq:
         requests:
           memory: 1G
-          cpu: 1000m
+          cpu: 250m
         limits:
           memory: 2G
   memcached:

--- a/infrastructure/yaook/nova.yaml
+++ b/infrastructure/yaook/nova.yaml
@@ -194,7 +194,7 @@ spec:
       resources:
         rabbitmq:
           requests:
-            cpu: 1000m
+            cpu: 250m
             memory: 1G
           limits:
             memory: 2G
@@ -235,7 +235,7 @@ spec:
     resources:
       placement:
         requests:
-          cpu: 400m
+          cpu: 100m
           memory: 1Gi
         limits:
           memory: 2Gi


### PR DESCRIPTION
RabbitMQ pods were hitting 100% of the 250m CPU limit set in Phase 1. Actual usage shows bursts well above 250m (cinder-mq: 910m, nova-mq: 776m, designate-mq: 248m pegged).

- Requests stay at 250m (low scheduling cost)
- Limits restored to 1000m (burst headroom)

Prevents CPU throttling while maintaining the scheduling cost reduction.