### PR TITLE
fix: restore RabbitMQ CPU limits (1000m) with low requests (250m)

### DIFF
--- a/infrastructure/yaook/cinder.yaml
+++ b/infrastructure/yaook/cinder.yaml
@@ -97,6 +97,7 @@ spec:
           cpu: 250m
           memory: 1G
         limits:
+          cpu: 1000m
           memory: 2G
     scheduleRuleWhenUnsatisfiable: ScheduleAnyway
     storageSize: 8Gi

--- a/infrastructure/yaook/designate.yaml
+++ b/infrastructure/yaook/designate.yaml
@@ -50,8 +50,11 @@ spec:
     replicas: 1
     resources:
       rabbitmq:
-        limits:
+        requests:
           cpu: 250m
+          memory: 1G
+        limits:
+          cpu: 1000m
           memory: 1G
     scheduleRuleWhenUnsatisfiable: ScheduleAnyway
     storageSize: 8Gi

--- a/infrastructure/yaook/neutron.yaml
+++ b/infrastructure/yaook/neutron.yaml
@@ -52,6 +52,7 @@ spec:
           memory: 1G
           cpu: 250m
         limits:
+          cpu: 1000m
           memory: 2G
   memcached:
     connections: 1024

--- a/infrastructure/yaook/nova.yaml
+++ b/infrastructure/yaook/nova.yaml
@@ -197,6 +197,7 @@ spec:
             cpu: 250m
             memory: 1G
           limits:
+            cpu: 1000m
             memory: 2G
       scheduleRuleWhenUnsatisfiable: ScheduleAnyway
       storageSize: 8Gi


### PR DESCRIPTION
RabbitMQ pods hitting 100% of 250m limit. Actual usage: cinder-mq 910m, nova-mq 776m, designate-mq 248m.

- Requests stay at 250m (low scheduling cost)
- Limits restored to 1000m (burst headroom)