### PR TITLE
fix(monitoring): make the mgmt stack minimalist and stop the OOM/crash loops

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2521,6 +2521,67 @@ upstream yaook change.
 tenant VMs. The control-plane half (NB/SB/relay/northd) can be applied
 independently and is safe to do first.
 
+#### Monitoring: Prometheus OOM was cardinality, not tuning (mgmt cluster)
+
+**2026-07-26.** The mgmt monitoring stack had two INDEPENDENT faults that look
+alike from `kubectl get pods` but share no mechanism.
+
+**(a) `mimir-ingester-0` CrashLoopBackOff was DISK, not memory.** The log is
+explicit: `open /data/tsdb/anonymous/wal/00000256: no space left on device`.
+The live PVC was a stale **2Gi** while the StatefulSet template already carried
+5Gi. Fixed by expanding the PVC IN PLACE (`csi-cinder-sc-delete` has
+`allowVolumeExpansion: true`), then deleting the pod so the filesystem resize
+completes (the PVC sits at `FileSystemResizePending` until a pod restarts).
+
+> **Do NOT "fix" this by raising `ingester.persistentVolume.size`.** A
+> StatefulSet's `volumeClaimTemplates` are **immutable** — raising the value does
+> not resize anything, it makes the Helm upgrade fail outright with
+> `updates to statefulset spec for fields other than 'replicas' ... are
+forbidden`, wedging the release. Expand the PVC; leave the chart value alone.
+
+**(b) Prometheus OOM-looping with a 1Gi limit was CARDINALITY.** Measured:
+**313,505 active head series**. A head costs ~2-4 KB/series, so 1Gi could only
+ever OOM. The distribution is the whole story:
+
+```
+series by scrape job          top metrics by series
+  255,986  apiserver  (82%)     39,260  etcd_request_duration_seconds_bucket
+   31,832  kubelet               30,114  apiserver_watch_list_duration_seconds_bucket
+   12,733  kube-state-metrics    28,570  apiserver_request_duration_seconds_bucket
+    7,744  node-exporter         26,152  apiserver_watch_cache_read_wait_seconds_bucket
+```
+
+The apiserver is 82% of all series because this is a CAPI **management** cluster:
+most apiserver metrics are per-(resource x verb x le) and the CRD count is large.
+Dropping nine histogram families whole (`_bucket`+`_sum`+`_count`) plus genuinely
+inert metrics (`kubernetes_feature_enabled` — a STATIC feature-gate list;
+`apiextensions_openapi_v2/v3_regeneration_count`; six `apiserver_{storage,cache}_list_*`
+families; kubelet `prober_probe_duration_seconds`) takes it to **~108,600, a 65%
+cut**. `apiserver_request_total` is deliberately KEPT — `KubeAPIDown` and
+error-rate alerting need it. The `kubeApiserverSlos`/`Burnrate`/`Histogram`
+default rule groups are disabled to match, since they are built on the dropped
+buckets and would otherwise be permanently empty.
+
+**A memory limit alone is a CLIFF, not a safety net.** Go grows the heap until
+the kernel SIGKILLs it, so the pod dies, replays the WAL, and dies again — an OOM
+loop. `GOMEMLIMIT` (set to ~80% of the hard limit via
+`prometheusSpec.containers[].env`) is a SOFT limit that makes the GC trade CPU
+for memory instead of being killed. Also bound `remoteWrite.queueConfig.maxShards`:
+unbounded shards are a hidden memory sink when the remote is slow, which turns
+"Mimir is unhealthy" into "Prometheus OOMs".
+
+Local retention is 6h on purpose — this Prometheus is a **shipper**, not a store;
+Mimir owns retention via `compactor_blocks_retention_period`.
+
+**Renovate silently changed the Mimir architecture.** Chart 6.x defaults BOTH
+`kafka.enabled: true` and the templated `ingest_storage.enabled: true`, so the
+major bump (`8f5ff7f`) switched Mimir onto the experimental Kafka-backed write
+path and added a Kafka StatefulSet (+5Gi PVC) nobody asked for. Disabling it
+needs **both** flags: `kafka.enabled: false` stops the StatefulSet, and
+`mimir.structuredConfig.ingest_storage.enabled: false` stops Mimir trying to
+produce to a broker that no longer exists. Check `helm show values` on major
+chart bumps for defaults that change topology.
+
 #### Node resilience: MachineHealthCheck + kubelet reservations
 
 **2026-07-26.** Two gaps made a single sick node escalate into a cluster-wide
@@ -2814,7 +2875,9 @@ All configuration is declarative, version-controlled, and enables auditable infr
 
 ---
 
-**Last Updated**: July 26, 2026 (MTU: pinned `MTU: 1400` in `clusters/openstack/cilium.yaml`. ROOT CAUSE of the long-running `net/http: TLS handshake timeout` black hole: Cilium sets no explicit MTU, so it auto-detects the MINIMUM across its `--devices` — and this cluster attaches `br-int`, which OVN sizes to the TENANT MTU (1284). Cilium thus adopted the tenant MTU as its HOST MTU and, with `packetizationLayerPMTUDMode: always`, its BPF emitted ICMP frag-needed `mtu 1284` for ordinary host underlay traffic (captured: apiserver/6443 and kubelet/10250 between hypervisors), poisoning each hypervisor's PMTU cache for its peers. Geneve was then left `1284 − 58` = 1226 while Neutron advertised 1284 → a 58-byte silent black hole east-west AND north-south. This is a FEEDBACK LOOP (`path_mtu → br-int → Cilium MTU → ICMP → underlay PMTU`), so `dfe2403`'s `path_mtu` 1400→1342 could not fix it — it only moved the hole from 1342/1284 to 1284/1226. The underlay genuinely carries 1400 (proven with `ping -M probe` and a post-flush DF ping), so jumbo would not have helped either. Corrected the previous WRONG diagnosis that blamed the OVN distributed gateway port and explicitly ruled out Cilium. See "Cilium auto-MTU inherits `br-int`" in Section 8.)
+**Last Updated**: July 26, 2026 (Monitoring: made the mgmt stack minimalist and stable. TWO independent faults — `mimir-ingester-0` CrashLoopBackOff was DISK (stale 2Gi PVC vs a 5Gi StatefulSet template; expanded in place, since raising the chart value would instead wedge the Helm upgrade on the immutable `volumeClaimTemplates`), while Prometheus OOM-looping under a 1Gi limit was CARDINALITY: **313,505 active head series**, of which the apiserver job alone was 82%. Dropped nine apiserver/etcd histogram families whole plus inert metrics (`kubernetes_feature_enabled`, openapi regeneration counters, `apiserver_{storage,cache}_list_*`, kubelet `prober_probe_duration_seconds`) for a **65% cut to ~108,600 series**, keeping `apiserver_request_total` for `KubeAPIDown`; disabled the kube-apiserver SLO rule groups that depended on the dropped buckets. Added `GOMEMLIMIT` (a hard limit alone is a cliff → OOM loop; GOMEMLIMIT makes the GC trade CPU for memory), bounded `remoteWrite` shards, 60s scrape, 6h local retention (Mimir owns retention). Also disabled the Kafka/ingest-storage architecture that the Mimir v6 Renovate bump silently enabled, and added the missing `monitoring` Sveltos toggle to the chihiro ConfigMap. See "Monitoring: Prometheus OOM was cardinality, not tuning" in Section 8.)
+
+**Previously**: July 26, 2026 (MTU: pinned `MTU: 1400` in `clusters/openstack/cilium.yaml`. ROOT CAUSE of the long-running `net/http: TLS handshake timeout` black hole: Cilium sets no explicit MTU, so it auto-detects the MINIMUM across its `--devices` — and this cluster attaches `br-int`, which OVN sizes to the TENANT MTU (1284). Cilium thus adopted the tenant MTU as its HOST MTU and, with `packetizationLayerPMTUDMode: always`, its BPF emitted ICMP frag-needed `mtu 1284` for ordinary host underlay traffic (captured: apiserver/6443 and kubelet/10250 between hypervisors), poisoning each hypervisor's PMTU cache for its peers. Geneve was then left `1284 − 58` = 1226 while Neutron advertised 1284 → a 58-byte silent black hole east-west AND north-south. This is a FEEDBACK LOOP (`path_mtu → br-int → Cilium MTU → ICMP → underlay PMTU`), so `dfe2403`'s `path_mtu` 1400→1342 could not fix it — it only moved the hole from 1342/1284 to 1284/1226. The underlay genuinely carries 1400 (proven with `ping -M probe` and a post-flush DF ping), so jumbo would not have helped either. Corrected the previous WRONG diagnosis that blamed the OVN distributed gateway port and explicitly ruled out Cilium. See "Cilium auto-MTU inherits `br-int`" in Section 8.)
 
 **Previously**: July 26, 2026 (OVN: set `resources` on every component in `infrastructure/yaook/neutron.yaml` `setup.ovn` — NB/SB ovsdb + their ssl-terminators, the SB relay, `northd`, and the per-node `controller.*` agents were ALL QoS BestEffort (`resources: {}`), so on a node at load 69/12-cores they were starved until `ovsdb-server` could not answer a local appctl within the 20s liveness timeout; kubelet then killed them in a loop, NB raft lost quorum (term 676, no leader), `ovn-northd` could never find a leader and flapped 0/1, and Neutron could not bind ports so new VMs failed to boot. No CPU limits anywhere, and no memory limit on `ovs-vswitchd`. The CRD exposes no `priorityClassName`, so the `system-cluster-critical` half of the fix needs an upstream yaook change. See "OVN control plane must not be BestEffort" in Section 8.)
 

--- a/clusters/mgmt/apps/chihiro/cm.yaml
+++ b/clusters/mgmt/apps/chihiro/cm.yaml
@@ -95,6 +95,7 @@ data:
             sveltos.argus.rpcu.io/external-dns: {{ chihiro.externalDns }}
             sveltos.argus.rpcu.io/gateway-api: {{ chihiro.gatewayApi }}
             sveltos.argus.rpcu.io/csi-driver-nfs: {{ chihiro.csiDriverNfs }}
+            sveltos.argus.rpcu.io/monitoring: {{ chihiro.monitoring }}
             type: workload
         spec:
           clusterNetwork:
@@ -284,3 +285,12 @@ data:
           false_value: disabled
           editable: true
           path: "metadata.labels.'sveltos.argus.rpcu.io/csi-driver-nfs'"
+        monitoring:
+          label: "Monitoring"
+          description: "Enable kube-prometheus-stack via Sveltos, remote_writing metrics to the central Mimir on mgmt (https://mimir.mgmt.rpcu.lan)"
+          type: boolean
+          default: true
+          true_value: enabled
+          false_value: disabled
+          editable: true
+          path: "metadata.labels.'sveltos.argus.rpcu.io/monitoring'"

--- a/clusters/mgmt/monitoring.yaml
+++ b/clusters/mgmt/monitoring.yaml
@@ -36,7 +36,16 @@ spec:
                 externalLabels:
                   cluster: mgmt
                 remoteWrite:
+                  # queueConfig MUST be repeated here: this patch replaces the
+                  # whole remoteWrite list (a strategic-merge patch treats an
+                  # unkeyed list as atomic), so omitting it would silently drop
+                  # the base's queue bounds and let the shards grow unbounded.
                   - url: http://mimir-gateway.monitoring.svc:80/api/v1/push
+                    queueConfig:
+                      capacity: 2500
+                      maxShards: 5
+                      minShards: 1
+                      maxSamplesPerSend: 1000
       target:
         kind: HelmRelease
         name: kube-prometheus-stack

--- a/infrastructure/mimir/helmrelease.yaml
+++ b/infrastructure/mimir/helmrelease.yaml
@@ -37,6 +37,21 @@ spec:
       config:
         resolver: "10.96.0.10 valid=10s"
 
+    # --- Ingest-storage (Kafka) architecture: DISABLED ---
+    # Chart 6.x defaults BOTH `kafka.enabled: true` and the templated
+    # `ingest_storage.enabled: true`, so the Renovate major bump to v6 (8f5ff7f)
+    # silently switched Mimir onto the experimental Kafka-backed write path and
+    # added a whole Kafka StatefulSet (+5Gi PVC) nobody asked for. For a central
+    # TSDB serving 2-3 small clusters this is pure overhead: it buys durability
+    # and replay semantics that only matter at multi-tenant scale, in exchange
+    # for an extra stateful component to run, size and keep alive.
+    #
+    # Disabling it reverts to the classic distributor -> ingester gRPC path.
+    # NOTE: this changes the ingester topology (it drops the partitions ring),
+    # so the ingester is recreated on rollout.
+    kafka:
+      enabled: false
+
     # --- Minimal lightweight deployment (1 replica per component) ---
     ingester:
       replicas: 1
@@ -44,6 +59,22 @@ spec:
         enabled: false
       persistentVolume:
         enabled: true
+        # KEEP AT 5Gi. A StatefulSet's volumeClaimTemplates are IMMUTABLE, so
+        # raising this number does NOT resize an existing PVC — it makes the
+        # Helm upgrade fail outright with "updates to statefulset spec for
+        # fields other than 'replicas' ... are forbidden", wedging the release.
+        #
+        # The live STS template already carries 5Gi; the PVC was created earlier
+        # at 2Gi and filled up, which is what put the ingester into
+        # CrashLoopBackOff ("open /data/tsdb/anonymous/wal/00000256: no space
+        # left on device"). The fix is to expand the PVC IN PLACE to match this
+        # value (csi-cinder-sc-delete has allowVolumeExpansion: true):
+        #
+        #   kubectl patch pvc storage-mimir-ingester-0 -n monitoring \
+        #     -p '{"spec":{"resources":{"requests":{"storage":"5Gi"}}}}'
+        #
+        # 5Gi is ample now: the kube-apiserver histogram drop plus the 60s
+        # scrape interval cut ingestion roughly 4x.
         size: 5Gi
       resources:
         requests:
@@ -112,8 +143,22 @@ spec:
     # --- Filesystem storage & clean memberlist ring for single replica ---
     mimir:
       structuredConfig:
+        # Disable the Kafka-backed write path templated in by chart 6.x. Must be
+        # set here as well as `kafka.enabled: false` above: that flag only stops
+        # the Kafka StatefulSet being deployed, while this is what stops Mimir
+        # itself trying to produce to it (otherwise the ingester starts the
+        # partitions-ring modules and fails to reach a broker that isn't there).
+        ingest_storage:
+          enabled: false
         limits:
-          max_global_series_per_user: 500000
+          # Lowered from 500k. The mgmt Prometheus alone was pushing 313k active
+          # series before the kube-apiserver histogram drop; a limit far above
+          # what the cluster should ever legitimately emit is not a safety net,
+          # it just lets a cardinality explosion land in the ingester's memory
+          # before anything complains. 200k is comfortably above the expected
+          # post-drop steady state (~150k across all clusters) and low enough to
+          # fail loudly and early.
+          max_global_series_per_user: 200000
           compactor_blocks_retention_period: 72h
         memberlist:
           join_members:

--- a/infrastructure/monitoring/helmrelease.yaml
+++ b/infrastructure/monitoring/helmrelease.yaml
@@ -38,12 +38,88 @@ spec:
     grafana:
       enabled: false
 
+    # --- Default alerting/recording rules ---
+    # The kube-apiserver SLO rule groups are DISABLED because they are built on
+    # apiserver_request_duration_seconds_bucket, which we drop below (see the
+    # cardinality note). Leaving them enabled would evaluate rules against a
+    # metric that no longer exists — permanently empty recording rules and
+    # alerts that can never fire. Disabling them is also a memory saving in
+    # itself: the burnrate group alone is ~30 recording rules over the highest
+    # cardinality series in the cluster.
+    defaultRules:
+      rules:
+        kubeApiserverBurnrate: false
+        kubeApiserverHistogram: false
+        kubeApiserverSlos: false
+
+    # --- kube-apiserver scrape: drop the high-cardinality histograms ---
+    # MEASURED on mgmt (6 nodes): the Prometheus head held 313,505 active series,
+    # of which these nine bucket metrics alone were ~164,000 — 53% of the total.
+    # A Prometheus head costs roughly 2-4 KB per active series, so those buckets
+    # were on their own worth ~0.5 GB of RSS, which is why a 1Gi limit could only
+    # ever OOM-loop. They are per-(resource x verb x le) histograms and explode
+    # on a CAPI management cluster because of the CRD count.
+    #
+    # This REPLACES the chart's own default metricRelabelings, which only dropped
+    # selected `le` values of a few of these. Dropping the whole metric is a
+    # superset of that rule, so nothing is lost by replacing it.
+    kubeApiServer:
+      serviceMonitor:
+        metricRelabelings:
+          # (1) Whole histogram FAMILIES (_bucket + _sum + _count). Dropping the
+          # buckets but keeping _sum/_count would leave the two most expensive
+          # offenders' tails behind (etcd_request_duration_seconds_sum/_count
+          # were 3,926 series each) for data nothing queries once the SLO rule
+          # groups are off.
+          - action: drop
+            sourceLabels: [__name__]
+            regex: (apiserver_request_duration_seconds|apiserver_request_sli_duration_seconds|apiserver_request_slo_duration_seconds|apiserver_watch_list_duration_seconds|apiserver_watch_cache_read_wait_seconds|apiserver_watch_events_sizes|apiserver_request_body_size_bytes|apiserver_response_sizes|etcd_request_duration_seconds)_(bucket|sum|count)
+          # (2) Metrics that are simply not pertinent here:
+          #   kubernetes_feature_enabled            2,178 - a STATIC list of
+          #     feature-gate names/stages. It never changes at runtime; it is
+          #     configuration, not telemetry.
+          #   apiextensions_openapi_v2/v3_regen     4,263 - per-CRD OpenAPI spec
+          #     regeneration counters. Pure apiserver-internal bookkeeping, and
+          #     they scale with CRD count, which is exactly what is large here.
+          #   apiserver_{storage,cache}_list_*     ~11,200 - six near-identical
+          #     per-resource list-accounting families. Useful when debugging
+          #     apiserver LIST amplification; dead weight the other 99% of time.
+          #   etcd_requests_total                   3,926 - per-(operation x type)
+          #     counter already covered by the kubeEtcd job for alerting.
+          - action: drop
+            sourceLabels: [__name__]
+            regex: (kubernetes_feature_enabled|etcd_requests_total|apiextensions_openapi_v2_regeneration_count|apiextensions_openapi_v3_regeneration_count|apiserver_storage_list_.*|apiserver_cache_list_.*|apiserver_resource_objects)
+    # kubelet: prober_probe_duration_seconds is a per-(pod x container x probe)
+    # histogram (2,736 series) reporting how long liveness/readiness probes take.
+    # Probe FAILURES surface as pod restarts and events, which are already
+    # covered; probe latency is not something anyone alerts on here.
+    kubelet:
+      serviceMonitor:
+        metricRelabelings:
+          - action: drop
+            sourceLabels: [__name__]
+            regex: prober_probe_duration_seconds_(bucket|sum|count)
+
     # --- Prometheus ---
     prometheus:
       prometheusSpec:
-        # Retention configured to 72h (3 days) with 5GB max retention size and 5Gi PVC storage.
-        retention: 72h
-        retentionSize: 5GB
+        # This Prometheus is a SHIPPER, not a store: every sample is
+        # remote_written to the central Mimir, which owns long-term retention
+        # (compactor_blocks_retention_period). Local retention therefore only
+        # needs to cover remote-write buffering and short "what is happening
+        # right now" queries, so it is deliberately short. Cutting 72h -> 6h
+        # shrinks the on-disk blocks and, more importantly, the number of
+        # memory-mapped head chunks Prometheus keeps resident.
+        retention: 6h
+        retentionSize: 3GB
+        # walCompression is the chart default but pinned explicitly: it roughly
+        # halves WAL size/IO, which matters on Cinder-backed PVCs.
+        walCompression: true
+        # 30s -> 60s halves the ingestion rate (measured 10,903 samples/sec).
+        # This is the deliberate "sacrifice a bit of responsiveness" trade: the
+        # worst case is noticing a change up to 60s later.
+        scrapeInterval: 60s
+        evaluationInterval: 60s
         storageSpec:
           volumeClaimTemplate:
             spec:
@@ -51,16 +127,44 @@ spec:
               resources:
                 requests:
                   storage: 5Gi
+        # Sized from the post-drop series count (~150k), not guessed. Requests
+        # are what the scheduler reserves; the limit is headroom for WAL replay
+        # and query spikes. No CPU limit on purpose — CFS throttling a scrape
+        # loop causes missed scrapes, and the same rationale is already applied
+        # to the Ceph and OVN daemons elsewhere in this repo.
         resources:
           requests:
-            cpu: 50m
-            memory: 256Mi
+            cpu: 100m
+            memory: 512Mi
           limits:
-            memory: 1Gi
+            memory: 1536Mi
+        # GOMEMLIMIT is the key to "resilient instead of OOM-looping". A cgroup
+        # memory limit alone is a CLIFF: Go happily grows the heap until the
+        # kernel SIGKILLs it, so the pod dies, replays the WAL, and dies again.
+        # GOMEMLIMIT is a SOFT limit that makes the Go GC progressively more
+        # aggressive as the heap approaches it, trading CPU for memory instead
+        # of being killed. Set to ~80% of the hard limit so there is room for
+        # non-heap memory (mmapped chunks, stacks) under the cgroup cap.
+        containers:
+          - name: prometheus
+            env:
+              - name: GOMEMLIMIT
+                value: "1200MiB"
         externalLabels:
           cluster: mgmt
         remoteWrite:
           - url: http://mimir-gateway.monitoring.svc:80/api/v1/push
+            # Bound the remote-write buffers. Unbounded shards are a common
+            # hidden source of Prometheus memory growth when the remote is slow
+            # or down (as Mimir has been): each shard holds an in-memory queue,
+            # so a backlog silently inflates RSS. Capping shards makes the
+            # failure mode "remote-write falls behind" rather than "Prometheus
+            # OOMs because the remote is unhealthy".
+            queueConfig:
+              capacity: 2500
+              maxShards: 5
+              minShards: 1
+              maxSamplesPerSend: 1000
 
     # --- AlertManager ---
     alertmanager:


### PR DESCRIPTION
Two independent faults that looked alike from `kubectl get pods`.

## (a) mimir-ingester CrashLoopBackOff was DISK

`open /data/tsdb/anonymous/wal/00000256: no space left on device`. The live PVC was a stale **2Gi** while the StatefulSet template already carried 5Gi. Fixed by expanding the PVC in place (already applied live; ingester is Running).

The chart value stays **5Gi on purpose**: `volumeClaimTemplates` are immutable, so raising it does not resize anything — it fails the Helm upgrade with `updates to statefulset spec ... are forbidden`.

## (b) Prometheus OOM was CARDINALITY, not tuning

Measured **313,505 active head series** against a 1Gi limit. At ~2–4 KB/series the head alone exceeded it, so OOM was structurally guaranteed.

```
series by scrape job          top metrics by series
  255,986  apiserver  (82%)     39,260  etcd_request_duration_seconds_bucket
   31,832  kubelet               30,114  apiserver_watch_list_duration_seconds_bucket
   12,733  kube-state-metrics    28,570  apiserver_request_duration_seconds_bucket
    7,744  node-exporter         26,152  apiserver_watch_cache_read_wait_seconds_bucket
```

**313,505 -> ~108,600 (65% cut)**: nine apiserver/etcd histogram families dropped whole, plus inert metrics (`kubernetes_feature_enabled` = a static feature-gate list, openapi regeneration counters, six `apiserver_{storage,cache}_list_*` families, kubelet `prober_probe_duration_seconds`).

`apiserver_request_total` is **kept** (KubeAPIDown / error-rate alerting). The `kubeApiserverSlos`/`Burnrate`/`Histogram` rule groups are disabled to match — they are built on the dropped buckets and would be permanently empty.

## Resilience instead of an OOM cliff

- **`GOMEMLIMIT=1200MiB`** under a 1536Mi limit. A cgroup limit alone is a cliff: Go grows the heap until SIGKILL, replays the WAL, dies again. GOMEMLIMIT is a soft limit that makes the GC trade CPU for memory.
- **Bounded `remoteWrite` shards** — unbounded shards are a hidden memory sink when the remote is slow, turning "Mimir is unhealthy" into "Prometheus OOMs". Repeated in the mgmt patch because a strategic-merge patch replaces the whole unkeyed list.
- **60s scrape** (measured 10,903 samples/sec) and **6h local retention** — Prometheus is a shipper; Mimir owns retention.

## Mimir: undo the architecture Renovate silently changed

Chart 6.x defaults **both** `kafka.enabled` and the templated `ingest_storage.enabled` to true, so `8f5ff7f` switched Mimir onto the experimental Kafka-backed write path and added a Kafka StatefulSet (+5Gi PVC). Disabled both. Also lowered `max_global_series_per_user` 500k -> 200k so a cardinality explosion fails loudly instead of landing in ingester memory.

## chihiro

Added the missing `monitoring` Sveltos toggle — it was the only ClusterProfile with no form field.

## Rollout note

Disabling ingest-storage changes the ingester topology (drops the partitions ring), so the ingester is recreated.