### PR TITLE
fix(monitoring): unbreak mimir ingester, restore kubelet relabel default, persist grafana

### DIFF
--- a/infrastructure/grafana/grafana.yaml
+++ b/infrastructure/grafana/grafana.yaml
@@ -37,6 +37,22 @@ spec:
             fsGroup: 472
             runAsNonRoot: true
             runAsUser: 472
+          # Mount the PVC declared under spec.persistentVolumeClaim below.
+          # grafana-operator v5 CREATES that PVC but does NOT wire it into the
+          # Deployment — the generated pod defaults `grafana-data` to an
+          # emptyDir, so without this override Grafana ran entirely ephemerally
+          # while a 5Gi Cinder volume sat bound and unused (and invisible to the
+          # PVC dashboard, since kubelet_volume_stats_* only reports MOUNTED
+          # volumes). Overriding the volume by name replaces that emptyDir.
+          #
+          # Dashboards/datasources are declarative (GrafanaDashboard /
+          # GrafanaDatasource CRs) so they always survive a restart; what this
+          # actually preserves is the sqlite DB — users/orgs, preferences,
+          # annotations and alert state.
+          volumes:
+            - name: grafana-data
+              persistentVolumeClaim:
+                claimName: grafana-pvc
           containers:
             - name: grafana
               env:

--- a/infrastructure/mimir/helmrelease.yaml
+++ b/infrastructure/mimir/helmrelease.yaml
@@ -164,6 +164,14 @@ spec:
           join_members:
             - mimir-gossip-ring.monitoring.svc.mgmt.local.
         ingester:
+          # REQUIRED when ingest_storage is disabled above. Chart 6.x hardcodes
+          # `ingester.push_grpc_method_enabled: false` because the ingest-storage
+          # architecture expects every write to arrive via Kafka rather than the
+          # Push gRPC API. Turning ingest_storage off without re-enabling this
+          # leaves Mimir with no write path at all, and it refuses to start:
+          #   "cannot disable Push gRPC method in ingester, while ingest storage
+          #    (-ingest-storage.enabled) is not enabled"
+          push_grpc_method_enabled: true
           ring:
             unregister_on_shutdown: true
             replication_factor: 1

--- a/infrastructure/monitoring/helmrelease.yaml
+++ b/infrastructure/monitoring/helmrelease.yaml
@@ -96,6 +96,12 @@ spec:
     kubelet:
       serviceMonitor:
         metricRelabelings:
+          # KEEP the chart's own default first — setting metricRelabelings
+          # REPLACES it wholesale, and dropping this by accident would quietly
+          # re-inflate kubelet storage-operation bucket cardinality.
+          - action: drop
+            sourceLabels: [__name__, le]
+            regex: (csi_operations|storage_operation_duration)_seconds_bucket;(0.25|2.5|15|25|120|600)(\.0)?
           - action: drop
             sourceLabels: [__name__]
             regex: prober_probe_duration_seconds_(bucket|sum|count)


### PR DESCRIPTION
Three follow-ups to #440, all found by verifying the live result rather than assuming it worked.

1. **mimir ingester refused to start** — `cannot disable Push gRPC method in ingester, while ingest storage (-ingest-storage.enabled) is not enabled`. Chart 6.x hardcodes `ingester.push_grpc_method_enabled: false` because ingest-storage expects every write via Kafka; turning ingest_storage off without re-enabling this leaves Mimir with **no write path at all**. Mimir was returning empty results for every query.
2. **kubelet metricRelabelings clobbered a chart default** — setting it replaces the chart's rule wholesale, which silently re-inflated `csi_operations`/`storage_operation_duration` bucket cardinality. Chart rule kept, ours appended.
3. **Grafana ran entirely ephemerally** — grafana-operator v5 creates the PVC from `spec.persistentVolumeClaim` but does *not* wire it into the Deployment, which defaults `grafana-data` to an emptyDir. A 5Gi Cinder volume was bound and unused (and invisible on the PVC dashboard, since `kubelet_volume_stats_*` only reports **mounted** volumes). Dashboards/datasources are declarative CRs so were never at risk; this preserves the sqlite DB.