### PR TITLE
fix(monitoring): unblock mimir writes, fix PVC metrics, monitor openstack cluster

### DIFF
--- a/clusters/openstack/kustomization.yaml
+++ b/clusters/openstack/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
   - external-secrets.yaml
   - flux-operator.yaml
   - rook.yaml
+  - monitoring.yaml
   - golinky.yaml
   - yaook-operator.yaml
   - fluxcd/

--- a/clusters/openstack/monitoring.yaml
+++ b/clusters/openstack/monitoring.yaml
@@ -1,0 +1,80 @@
+# kube-prometheus-stack on the BAREMETAL openstack cluster.
+#
+# Uses the SAME base as mgmt and the workload clusters
+# (infrastructure/monitoring), patched only for the two things that are
+# per-cluster: where to remote_write, and what to call this cluster.
+#
+# Pattern: identical to clusters/mgmt/monitoring.yaml (shared base + patches).
+#
+# UNLIKE mgmt, this cluster has no local Mimir — it ships every sample to the
+# central Mimir on the mgmt cluster over the PUBLIC gateway endpoint
+# (https://mimir.mgmt.rpcu.lan, TLS terminated by kgateway with the
+# rpcu-lan-wildcard-tls cert issued by the root-mgmt CA). That is the same
+# endpoint the Sveltos `monitoring` ClusterProfile points workload clusters at
+# (infrastructure/sveltos/clusterprofiles/monitoring.yaml), so all clusters land
+# in one tenant and the shared Grafana dashboards can select between them with
+# the `cluster` label.
+#
+# PREREQUISITE (manual, one-off): the `mimir-ca` secret in the `monitoring`
+# namespace, holding the root-mgmt CA under key `ca.crt`. Without it the
+# remote_write TLS handshake fails, because this cluster's trust bundle is the
+# RPCU root CA and knows nothing about root-mgmt. Workload clusters get this
+# pushed by Sveltos from the mgmt `root-mgmt` secret; the baremetal cluster is
+# not Sveltos-managed, so it is placed by hand:
+#
+#   kubectl --context mgmt -n cert-manager get secret root-mgmt \
+#     -o jsonpath='{.data.ca\.crt}' | base64 -d > /tmp/root-mgmt.crt
+#   kubectl --context openstack -n monitoring create secret generic mimir-ca \
+#     --from-file=ca.crt=/tmp/root-mgmt.crt
+#
+# `wait: false` for exactly that reason: until the secret exists the Prometheus
+# pod runs fine but remote_write errors, and we do not want that to block the
+# Kustomization (same rationale as capo-identity / openstack-ccm-identity).
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: monitoring
+  namespace: flux-system
+spec:
+  interval: 10m0s
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  path: ./infrastructure/monitoring
+  prune: true
+  wait: false
+  timeout: 10m
+  patches:
+    # Inject openstack-specific remote_write + externalLabels.
+    - patch: |
+        apiVersion: helm.toolkit.fluxcd.io/v2
+        kind: HelmRelease
+        metadata:
+          name: kube-prometheus-stack
+        spec:
+          values:
+            prometheus:
+              prometheusSpec:
+                externalLabels:
+                  cluster: openstack
+                remoteWrite:
+                  # queueConfig MUST be repeated here: this patch replaces the
+                  # whole remoteWrite list (a strategic-merge patch treats an
+                  # unkeyed list as atomic), so omitting it would silently drop
+                  # the base's queue bounds and let the shards grow unbounded.
+                  - url: https://mimir.mgmt.rpcu.lan/api/v1/push
+                    tlsConfig:
+                      ca:
+                        secret:
+                          name: mimir-ca
+                          key: ca.crt
+                    queueConfig:
+                      capacity: 2500
+                      maxShards: 5
+                      minShards: 1
+                      maxSamplesPerSend: 1000
+      target:
+        kind: HelmRelease
+        name: kube-prometheus-stack
+        namespace: monitoring

--- a/infrastructure/grafana/dashboards/pvc-storage-dashboard.yaml
+++ b/infrastructure/grafana/dashboards/pvc-storage-dashboard.yaml
@@ -57,7 +57,7 @@ spec:
           "targets": [
             {
               "datasource": { "type": "prometheus", "uid": "Mimir" },
-              "expr": "count(kubelet_volume_stats_capacity_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\"})",
+              "expr": "count(kube_persistentvolumeclaim_info{cluster=~\"$cluster\", namespace=~\"$namespace\"})",
               "legendFormat": "Total PVCs",
               "refId": "A"
             }
@@ -268,6 +268,14 @@ spec:
               "instant": true,
               "legendFormat": "",
               "refId": "Usage Gauge"
+            },
+            {
+              "datasource": { "type": "prometheus", "uid": "Mimir" },
+              "expr": "kube_persistentvolumeclaim_resource_requests_storage_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\"}",
+              "format": "table",
+              "instant": true,
+              "legendFormat": "",
+              "refId": "Requested"
             }
           ],
           "title": "Complete PVC Inventory Listing (All Clusters & Namespaces)",

--- a/infrastructure/mimir/helmrelease.yaml
+++ b/infrastructure/mimir/helmrelease.yaml
@@ -164,10 +164,19 @@ spec:
           # remote_write into 81% failure (2.19M of 2.70M samples rejected) while
           # the head was still at 323k.
           #
-          # 400k leaves room for the transition, for the other clusters that
-          # remote_write into this same tenant, and for normal growth, while
-          # still failing loudly long before the ingester eats all its memory.
-          max_global_series_per_user: 400000
+          # CRITICAL: this is enforced against the ingester's MEMORY series
+          # (cortex_ingester_memory_series), NOT its ACTIVE series
+          # (cortex_ingester_active_series). Those diverge hugely during a
+          # transition: measured 144,039 active but 412,417 in memory, because
+          # Prometheus replays its remote-write WAL backlog (re-pushing the very
+          # series we just dropped) and idle series are not purged until head
+          # compaction ~2h later. Sizing against the active count is what made
+          # both 200k and 400k reject writes.
+          #
+          # 600k is headroom for that transient peak plus the other clusters
+          # writing into this same tenant. Steady state is ~144k, so this still
+          # fails loudly long before the ingester exhausts its 2Gi limit.
+          max_global_series_per_user: 600000
           compactor_blocks_retention_period: 72h
         memberlist:
           join_members:


### PR DESCRIPTION
## mimir: series limit 400k -> 600k

The limit is enforced against the ingester's **memory** series, not its **active** series, and those diverge hugely during a transition:

```
cortex_ingester_active_series{user="anonymous"} = 144,039   <- steady state
cortex_ingester_memory_series                  = 412,417   <- what the limit checks
```

Prometheus replays its remote-write WAL backlog (re-pushing the series just dropped) and idle series are not purged until head compaction ~2h later. Sizing against the active count is why both 200k and 400k rejected writes with `err-mimir-max-series-per-user`, leaving Mimir empty and **every dashboard blank**. Steady state is ~144k, so 600k still fails loudly before the ingester OOMs.

## PVC dashboard: it was structurally blind

Built entirely on `kubelet_volume_stats_*`, which the kubelet only emits for **mounted** volumes — so the panel titled *"Complete PVC Inventory"* saw **12 of 19** PVCs. Unmounted claims (including the 7 orphaned pre-v6 mimir `zone-*` volumes) were invisible, which is precisely what you want a storage dashboard to surface.

- PVC count -> `kube_persistentvolumeclaim_info` (19, not 12)
- inventory table gains requested size -> `kube_persistentvolumeclaim_resource_requests_storage_bytes`

kube-state-metrics reports both for every claim regardless of mount state. Usage/free still come from kubelet stats, since only the kubelet can measure actual bytes used.

## openstack cluster monitoring

Adds kube-prometheus-stack to the baremetal cluster reusing the **same shared base** as mgmt and the workload clusters, remote_writing to the central Mimir at `https://mimir.mgmt.rpcu.lan` with `externalLabels.cluster=openstack` — one tenant, unified Grafana dashboards with a working cluster selector.

**Requires a one-off manual `mimir-ca` secret** (root-mgmt CA in ns `monitoring`): this cluster's trust bundle is the RPCU root CA and knows nothing about root-mgmt. Command is in the file header. `wait: false` so its absence doesn't block the Kustomization.