### PR TITLE
feat(metrics-server): add GitOps-managed metrics-server to mgmt and openstack

### DIFF
--- a/clusters/mgmt/kustomization.yaml
+++ b/clusters/mgmt/kustomization.yaml
@@ -31,6 +31,7 @@ resources:
   - vault-unsealer.yaml
   - sveltos.yaml
   - kubernetes-rbac.yaml
+  - metrics-server.yaml
   - flux-operator.yaml
   - kamaji.yaml
   - fluxcd/

--- a/clusters/mgmt/metrics-server.yaml
+++ b/clusters/mgmt/metrics-server.yaml
@@ -1,0 +1,22 @@
+# metrics-server on the mgmt cluster — backs `kubectl top` and the CPU/memory
+# columns in k9s, and is what HorizontalPodAutoscaler reads.
+#
+# Uses the shared base (infrastructure/metrics-server) with NO patches: the
+# config is genuinely identical on every cluster here, so there is nothing to
+# override. Kept as a per-cluster Flux Kustomization only so each cluster
+# decides whether to deploy it.
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: metrics-server
+  namespace: flux-system
+spec:
+  interval: 10m0s
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  path: ./infrastructure/metrics-server
+  prune: true
+  wait: true
+  timeout: 5m

--- a/clusters/openstack/kustomization.yaml
+++ b/clusters/openstack/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
   - cilium.yaml
   - crossplane.yaml
   - external-secrets.yaml
+  - metrics-server.yaml
   - flux-operator.yaml
   - rook.yaml
   - monitoring.yaml

--- a/clusters/openstack/metrics-server.yaml
+++ b/clusters/openstack/metrics-server.yaml
@@ -1,0 +1,22 @@
+# metrics-server on the openstack cluster — backs `kubectl top` and the CPU/memory
+# columns in k9s, and is what HorizontalPodAutoscaler reads.
+#
+# Uses the shared base (infrastructure/metrics-server) with NO patches: the
+# config is genuinely identical on every cluster here, so there is nothing to
+# override. Kept as a per-cluster Flux Kustomization only so each cluster
+# decides whether to deploy it.
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: metrics-server
+  namespace: flux-system
+spec:
+  interval: 10m0s
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  path: ./infrastructure/metrics-server
+  prune: true
+  wait: true
+  timeout: 5m

--- a/infrastructure/metrics-server/helmrelease.yaml
+++ b/infrastructure/metrics-server/helmrelease.yaml
@@ -1,0 +1,56 @@
+# metrics-server — the Kubernetes Metrics API (metrics.k8s.io).
+#
+# This is what backs `kubectl top` and the CPU/memory columns in k9s. It is a
+# SEPARATE concern from the Prometheus/Mimir stack: Prometheus is for history,
+# dashboards and alerting; metrics-server is a short-lived in-memory cache
+# (~15s resolution, no history) that the core API serves. HorizontalPodAutoscaler
+# also reads it. Having Prometheus does NOT give you `kubectl top`.
+#
+# Shared base — deployed on:
+#   - mgmt      via clusters/mgmt/metrics-server.yaml
+#   - openstack via clusters/openstack/metrics-server.yaml
+#
+# `--kubelet-insecure-tls` is REQUIRED on these clusters: kubeadm/CAPO issue
+# kubelet *serving* certificates that are self-signed rather than signed by the
+# cluster CA (serving-cert rotation via the CSR API is not enabled), so
+# metrics-server cannot verify them and every scrape fails with
+# "x509: cannot validate certificate". This matches the flag set the
+# hand-installed metrics-server on the openstack cluster was already using.
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: metrics-server
+  namespace: kube-system
+spec:
+  interval: 10m
+  chart:
+    spec:
+      chart: metrics-server
+      version: 3.13.0
+      interval: 24h
+      sourceRef:
+        kind: HelmRepository
+        name: metrics-server
+        namespace: kube-system
+  install:
+    crds: CreateReplace
+  upgrade:
+    crds: CreateReplace
+  values:
+    args:
+      - --kubelet-insecure-tls
+      - --kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname
+      - --metric-resolution=15s
+    # Deliberately small: metrics-server holds only the most recent scrape for
+    # each node/pod in memory, so its footprint scales with cluster size, not
+    # with time. These are comfortable for the ~6-node clusters here.
+    resources:
+      requests:
+        cpu: 25m
+        memory: 64Mi
+      limits:
+        memory: 192Mi
+    # Single replica. HA would need --enable-aggregator-routing on the apiserver
+    # and buys little: if metrics-server is briefly down you lose `kubectl top`,
+    # not any stored data.
+    replicas: 1

--- a/infrastructure/metrics-server/helmrepo.yaml
+++ b/infrastructure/metrics-server/helmrepo.yaml
@@ -1,0 +1,8 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: metrics-server
+  namespace: kube-system
+spec:
+  interval: 24h
+  url: https://kubernetes-sigs.github.io/metrics-server/

--- a/infrastructure/metrics-server/kustomization.yaml
+++ b/infrastructure/metrics-server/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: kube-system
+resources:
+  - helmrepo.yaml
+  - helmrelease.yaml


### PR DESCRIPTION
`metrics-server` backs `kubectl top` and the CPU/memory columns in **k9s**, and is what HPA reads. It is a separate concern from Prometheus/Mimir — Prometheus is history/dashboards/alerting, metrics-server is a ~15s in-memory cache served through the core API. Having Prometheus does **not** give you `kubectl top`.

State before:
- **mgmt**: none at all — this is why `kubectl top` returned `Metrics API not available` throughout the monitoring work.
- **openstack**: installed by hand 91 days ago from the upstream manifest (bare `k8s-app=metrics-server` label, no Helm/Flux ownership) — invisible to GitOps and drifting.

One shared base, used **unpatched** by both clusters since the config is genuinely identical; the per-cluster Kustomization exists only so each cluster opts in.

`--kubelet-insecure-tls` is required: kubeadm/CAPO issue self-signed kubelet *serving* certs (no CSR-API rotation), so verification fails with x509 errors. Same flags the hand-rolled install already used.

**Note on the openstack cluster:** the existing hand-installed Deployment must be deleted so the Helm release can own it cleanly (Helm will not adopt a resource it did not create). I have not done that yet — see the PR discussion.