### PR TITLE
fix(monitoring): add prometheus-adapter, repair broken cluster kustomizations

### DIFF
--- a/clusters/mgmt/kustomization.yaml
+++ b/clusters/mgmt/kustomization.yaml
@@ -31,7 +31,6 @@ resources:
   - vault-unsealer.yaml
   - sveltos.yaml
   - kubernetes-rbac.yaml
-  - prometheus-adapter.yaml
   - flux-operator.yaml
   - kamaji.yaml
   - fluxcd/

--- a/clusters/openstack/kustomization.yaml
+++ b/clusters/openstack/kustomization.yaml
@@ -8,7 +8,6 @@ resources:
   - cilium.yaml
   - crossplane.yaml
   - external-secrets.yaml
-  - prometheus-adapter.yaml
   - flux-operator.yaml
   - rook.yaml
   - monitoring.yaml

--- a/infrastructure/monitoring/kustomization.yaml
+++ b/infrastructure/monitoring/kustomization.yaml
@@ -3,3 +3,4 @@ resources:
   - namespace.yaml
   - helmrepo.yaml
   - helmrelease.yaml
+  - prometheus-adapter.yaml

--- a/infrastructure/monitoring/prometheus-adapter.yaml
+++ b/infrastructure/monitoring/prometheus-adapter.yaml
@@ -1,0 +1,80 @@
+# prometheus-adapter — serves the Kubernetes Metrics API (metrics.k8s.io) from
+# Prometheus, so `kubectl top`, the CPU/memory columns in k9s, and
+# HorizontalPodAutoscaler all work WITHOUT running a separate metrics-server.
+#
+# Deployed as part of the monitoring stack rather than as its own per-cluster
+# Kustomization: it is meaningless without a local Prometheus, its config is
+# identical on every cluster (the kube-prometheus-stack Service name is the
+# same everywhere), and bundling it means any cluster that gets monitoring gets
+# working `kubectl top` for free. No per-cluster patch is required.
+#
+# It REPLACES metrics-server: both register the same v1beta1.metrics.k8s.io
+# APIService, so they cannot coexist. Any hand-installed metrics-server must be
+# deleted first or the APIService will flap between the two backends.
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: prometheus-adapter
+  namespace: monitoring
+spec:
+  interval: 10m
+  chart:
+    spec:
+      chart: prometheus-adapter
+      version: 5.1.0
+      interval: 24h
+      sourceRef:
+        kind: HelmRepository
+        name: prometheus-community
+        namespace: monitoring
+  values:
+    prometheus:
+      url: http://kube-prometheus-stack-prometheus.monitoring.svc
+      port: 9090
+    resources:
+      requests:
+        cpu: 25m
+        memory: 64Mi
+      limits:
+        memory: 192Mi
+    rules:
+      # Only the resource rules are wanted (cpu/memory for top/HPA). The chart's
+      # default custom-metrics rules enumerate every series in Prometheus, which
+      # is expensive and pointless here.
+      default: false
+      resource:
+        cpu:
+          containerQuery: |
+            sum by (<<.GroupBy>>) (
+              rate(container_cpu_usage_seconds_total{<<.LabelMatchers>>, container!="", pod!=""}[3m])
+            )
+          nodeQuery: |
+            sum by (<<.GroupBy>>) (
+              rate(node_cpu_seconds_total{mode!="idle", mode!="iowait", <<.LabelMatchers>>}[3m])
+            )
+          resources:
+            overrides:
+              node: { resource: node }
+              namespace: { resource: namespace }
+              pod: { resource: pod }
+          containerLabel: container
+        memory:
+          containerQuery: |
+            sum by (<<.GroupBy>>) (
+              container_memory_working_set_bytes{<<.LabelMatchers>>, container!="", pod!=""}
+            )
+          nodeQuery: |
+            sum by (<<.GroupBy>>) (
+              node_memory_MemTotal_bytes{<<.LabelMatchers>>}
+              - node_memory_MemAvailable_bytes{<<.LabelMatchers>>}
+            )
+          resources:
+            overrides:
+              node: { resource: node }
+              namespace: { resource: namespace }
+              pod: { resource: pod }
+          containerLabel: container
+        # MUST be >= 2x the scrape interval or rate() sees too few samples and
+        # returns nothing, which shows up as blank columns in k9s. The stack now
+        # scrapes at 60s (see helmrelease.yaml), so 3m gives three samples.
+        window: 3m


### PR DESCRIPTION
**Urgent:** my previous commit renamed the metrics-server entry in both cluster `kustomization.yaml` files to `prometheus-adapter.yaml` without creating that file, wedging the root `flux-system` Kustomization on **both** clusters at `4314ad0`:

```
accumulating resources from 'prometheus-adapter.yaml': no such file
```

Fixed by dropping the per-cluster entries and shipping the adapter as part of the monitoring stack.

## prometheus-adapter

Serves `metrics.k8s.io` from Prometheus, so `kubectl top`, the CPU/memory columns in **k9s**, and HPA work without a separate metrics-server.

Placed inside `infrastructure/monitoring` because it is meaningless without a local Prometheus, its config is identical on every cluster (the kube-prometheus-stack Service name does not vary), and bundling it means any cluster that opts into monitoring gets `kubectl top` for free — **no per-cluster patch**, which is the DRY shape requested.

- only `resource` rules enabled — the chart's default custom-metrics rules enumerate every series in Prometheus
- `window: 3m` because the stack now scrapes at **60s** and `rate()` needs >= 2 samples, else k9s columns are blank

It **replaces** metrics-server (both register `v1beta1.metrics.k8s.io`), so the hand-installed one on openstack must be deleted or the APIService flaps.