### PR TITLE
feat(grafana): fix PVC capacity accounting, add fill gauge and node FS dashboard

### DIFF
--- a/infrastructure/grafana/dashboards/node-filesystem-dashboard.yaml
+++ b/infrastructure/grafana/dashboards/node-filesystem-dashboard.yaml
@@ -1,0 +1,201 @@
+# Node / hypervisor filesystem capacity, usage and free space.
+#
+# Sourced from node-exporter (node_filesystem_*), so it covers the REAL disks
+# of every monitored machine - including the baremetal openstack hypervisors
+# (lucy/makise/quinn) now that cluster ships metrics to the central Mimir.
+# This is deliberately separate from the PVC dashboard: that one measures
+# Kubernetes claims, this one measures physical filesystems.
+#
+# Pseudo-filesystems (tmpfs/overlay/squashfs/...) and kubelet bind-mounts are
+# excluded, otherwise every container mount is double-counted against the
+# underlying disk.
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: node-filesystem-overview
+  namespace: monitoring
+spec:
+  resyncPeriod: 5m
+  instanceSelector:
+    matchLabels:
+      dashboards: grafana-central
+  json:
+    "{\n  \"annotations\": {\n    \"list\": []\n  },\n  \"editable\": true,\n  \"graphTooltip\": 1,\n\
+    \  \"schemaVersion\": 39,\n  \"title\": \"Node Filesystem / Hypervisor Storage\",\n  \"uid\": \"node-filesystem-overview\"\
+    ,\n  \"tags\": [\n    \"storage\",\n    \"nodes\",\n    \"hypervisor\"\n  ],\n  \"time\": {\n    \"\
+    from\": \"now-6h\",\n    \"to\": \"now\"\n  },\n  \"refresh\": \"1m\",\n  \"panels\": [\n    {\n \
+    \     \"datasource\": {\n        \"type\": \"prometheus\",\n        \"uid\": \"Mimir\"\n      },\n\
+    \      \"fieldConfig\": {\n        \"defaults\": {\n          \"unit\": \"bytes\",\n          \"color\"\
+    : {\n            \"mode\": \"thresholds\"\n          },\n          \"thresholds\": {\n           \
+    \ \"mode\": \"absolute\",\n            \"steps\": [\n              {\n                \"color\": \"\
+    green\",\n                \"value\": null\n              }\n            ]\n          }\n        },\n\
+    \        \"overrides\": []\n      },\n      \"gridPos\": {\n        \"h\": 4,\n        \"w\": 6,\n\
+    \        \"x\": 0,\n        \"y\": 0\n      },\n      \"id\": 1,\n      \"options\": {\n        \"\
+    colorMode\": \"value\",\n        \"graphMode\": \"area\",\n        \"justifyMode\": \"auto\",\n  \
+    \      \"orientation\": \"auto\",\n        \"reduceOptions\": {\n          \"calcs\": [\n        \
+    \    \"lastNotNull\"\n          ],\n          \"fields\": \"\",\n          \"values\": false\n   \
+    \     },\n        \"textMode\": \"auto\"\n      },\n      \"targets\": [\n        {\n          \"\
+    datasource\": {\n            \"type\": \"prometheus\",\n            \"uid\": \"Mimir\"\n         \
+    \ },\n          \"expr\": \"sum(node_filesystem_size_bytes{cluster=~\\\"$cluster\\\", instance=~\\\
+    \"$node\\\", fstype!~\\\"tmpfs|overlay|squashfs|ramfs|iso9660|autofs|devtmpfs\\\", mountpoint!~\\\"\
+    /(run|var/lib/kubelet|boot/efi).*\\\"})\",\n          \"instant\": true,\n          \"refId\": \"\
+    A\"\n        }\n      ],\n      \"title\": \"Total Filesystem Size\",\n      \"type\": \"stat\"\n\
+    \    },\n    {\n      \"datasource\": {\n        \"type\": \"prometheus\",\n        \"uid\": \"Mimir\"\
+    \n      },\n      \"fieldConfig\": {\n        \"defaults\": {\n          \"unit\": \"bytes\",\n  \
+    \        \"color\": {\n            \"mode\": \"thresholds\"\n          },\n          \"thresholds\"\
+    : {\n            \"mode\": \"absolute\",\n            \"steps\": [\n              {\n            \
+    \    \"color\": \"green\",\n                \"value\": null\n              }\n            ]\n    \
+    \      }\n        },\n        \"overrides\": []\n      },\n      \"gridPos\": {\n        \"h\": 4,\n\
+    \        \"w\": 6,\n        \"x\": 6,\n        \"y\": 0\n      },\n      \"id\": 2,\n      \"options\"\
+    : {\n        \"colorMode\": \"value\",\n        \"graphMode\": \"area\",\n        \"justifyMode\"\
+    : \"auto\",\n        \"orientation\": \"auto\",\n        \"reduceOptions\": {\n          \"calcs\"\
+    : [\n            \"lastNotNull\"\n          ],\n          \"fields\": \"\",\n          \"values\"\
+    : false\n        },\n        \"textMode\": \"auto\"\n      },\n      \"targets\": [\n        {\n \
+    \         \"datasource\": {\n            \"type\": \"prometheus\",\n            \"uid\": \"Mimir\"\
+    \n          },\n          \"expr\": \"sum(node_filesystem_size_bytes{cluster=~\\\"$cluster\\\", instance=~\\\
+    \"$node\\\", fstype!~\\\"tmpfs|overlay|squashfs|ramfs|iso9660|autofs|devtmpfs\\\", mountpoint!~\\\"\
+    /(run|var/lib/kubelet|boot/efi).*\\\"}) - sum(node_filesystem_avail_bytes{cluster=~\\\"$cluster\\\"\
+    , instance=~\\\"$node\\\", fstype!~\\\"tmpfs|overlay|squashfs|ramfs|iso9660|autofs|devtmpfs\\\", mountpoint!~\\\
+    \"/(run|var/lib/kubelet|boot/efi).*\\\"})\",\n          \"instant\": true,\n          \"refId\": \"\
+    A\"\n        }\n      ],\n      \"title\": \"Total Used\",\n      \"type\": \"stat\"\n    },\n   \
+    \ {\n      \"datasource\": {\n        \"type\": \"prometheus\",\n        \"uid\": \"Mimir\"\n    \
+    \  },\n      \"fieldConfig\": {\n        \"defaults\": {\n          \"unit\": \"bytes\",\n       \
+    \   \"color\": {\n            \"mode\": \"thresholds\"\n          },\n          \"thresholds\": {\n\
+    \            \"mode\": \"absolute\",\n            \"steps\": [\n              {\n                \"\
+    color\": \"green\",\n                \"value\": null\n              }\n            ]\n          }\n\
+    \        },\n        \"overrides\": []\n      },\n      \"gridPos\": {\n        \"h\": 4,\n      \
+    \  \"w\": 6,\n        \"x\": 12,\n        \"y\": 0\n      },\n      \"id\": 3,\n      \"options\"\
+    : {\n        \"colorMode\": \"value\",\n        \"graphMode\": \"area\",\n        \"justifyMode\"\
+    : \"auto\",\n        \"orientation\": \"auto\",\n        \"reduceOptions\": {\n          \"calcs\"\
+    : [\n            \"lastNotNull\"\n          ],\n          \"fields\": \"\",\n          \"values\"\
+    : false\n        },\n        \"textMode\": \"auto\"\n      },\n      \"targets\": [\n        {\n \
+    \         \"datasource\": {\n            \"type\": \"prometheus\",\n            \"uid\": \"Mimir\"\
+    \n          },\n          \"expr\": \"sum(node_filesystem_avail_bytes{cluster=~\\\"$cluster\\\", instance=~\\\
+    \"$node\\\", fstype!~\\\"tmpfs|overlay|squashfs|ramfs|iso9660|autofs|devtmpfs\\\", mountpoint!~\\\"\
+    /(run|var/lib/kubelet|boot/efi).*\\\"})\",\n          \"instant\": true,\n          \"refId\": \"\
+    A\"\n        }\n      ],\n      \"title\": \"Total Available\",\n      \"type\": \"stat\"\n    },\n\
+    \    {\n      \"datasource\": {\n        \"type\": \"prometheus\",\n        \"uid\": \"Mimir\"\n \
+    \     },\n      \"fieldConfig\": {\n        \"defaults\": {\n          \"unit\": \"percent\",\n  \
+    \        \"color\": {\n            \"mode\": \"thresholds\"\n          },\n          \"thresholds\"\
+    : {\n            \"mode\": \"absolute\",\n            \"steps\": [\n              {\n            \
+    \    \"color\": \"green\",\n                \"value\": null\n              }\n            ]\n    \
+    \      }\n        },\n        \"overrides\": []\n      },\n      \"gridPos\": {\n        \"h\": 4,\n\
+    \        \"w\": 6,\n        \"x\": 18,\n        \"y\": 0\n      },\n      \"id\": 4,\n      \"options\"\
+    : {\n        \"colorMode\": \"value\",\n        \"graphMode\": \"area\",\n        \"justifyMode\"\
+    : \"auto\",\n        \"orientation\": \"auto\",\n        \"reduceOptions\": {\n          \"calcs\"\
+    : [\n            \"lastNotNull\"\n          ],\n          \"fields\": \"\",\n          \"values\"\
+    : false\n        },\n        \"textMode\": \"auto\"\n      },\n      \"targets\": [\n        {\n \
+    \         \"datasource\": {\n            \"type\": \"prometheus\",\n            \"uid\": \"Mimir\"\
+    \n          },\n          \"expr\": \"(1 - sum(node_filesystem_avail_bytes{cluster=~\\\"$cluster\\\
+    \", instance=~\\\"$node\\\", fstype!~\\\"tmpfs|overlay|squashfs|ramfs|iso9660|autofs|devtmpfs\\\"\
+    , mountpoint!~\\\"/(run|var/lib/kubelet|boot/efi).*\\\"}) / sum(node_filesystem_size_bytes{cluster=~\\\
+    \"$cluster\\\", instance=~\\\"$node\\\", fstype!~\\\"tmpfs|overlay|squashfs|ramfs|iso9660|autofs|devtmpfs\\\
+    \", mountpoint!~\\\"/(run|var/lib/kubelet|boot/efi).*\\\"})) * 100\",\n          \"instant\": true,\n\
+    \          \"refId\": \"A\"\n        }\n      ],\n      \"title\": \"Used %\",\n      \"type\": \"\
+    stat\"\n    },\n    {\n      \"datasource\": {\n        \"type\": \"prometheus\",\n        \"uid\"\
+    : \"Mimir\"\n      },\n      \"fieldConfig\": {\n        \"defaults\": {\n          \"unit\": \"percent\"\
+    ,\n          \"custom\": {\n            \"fillOpacity\": 8,\n            \"lineWidth\": 2\n      \
+    \    },\n          \"min\": 0,\n          \"max\": 100\n        },\n        \"overrides\": []\n  \
+    \    },\n      \"gridPos\": {\n        \"h\": 9,\n        \"w\": 24,\n        \"x\": 0,\n        \"\
+    y\": 4\n      },\n      \"id\": 5,\n      \"options\": {\n        \"legend\": {\n          \"displayMode\"\
+    : \"table\",\n          \"placement\": \"right\",\n          \"calcs\": [\n            \"lastNotNull\"\
+    ,\n            \"max\"\n          ]\n        },\n        \"tooltip\": {\n          \"mode\": \"multi\"\
+    ,\n          \"sort\": \"desc\"\n        }\n      },\n      \"targets\": [\n        {\n          \"\
+    datasource\": {\n            \"type\": \"prometheus\",\n            \"uid\": \"Mimir\"\n         \
+    \ },\n          \"expr\": \"(1 - node_filesystem_avail_bytes{cluster=~\\\"$cluster\\\", instance=~\\\
+    \"$node\\\", fstype!~\\\"tmpfs|overlay|squashfs|ramfs|iso9660|autofs|devtmpfs\\\", mountpoint!~\\\"\
+    /(run|var/lib/kubelet|boot/efi).*\\\"} / node_filesystem_size_bytes{cluster=~\\\"$cluster\\\", instance=~\\\
+    \"$node\\\", fstype!~\\\"tmpfs|overlay|squashfs|ramfs|iso9660|autofs|devtmpfs\\\", mountpoint!~\\\"\
+    /(run|var/lib/kubelet|boot/efi).*\\\"}) * 100\",\n          \"legendFormat\": \"{{cluster}} / {{instance}}\
+    \ {{mountpoint}}\",\n          \"refId\": \"A\"\n        }\n      ],\n      \"title\": \"Filesystem\
+    \ Used % per Mountpoint\",\n      \"type\": \"timeseries\"\n    },\n    {\n      \"datasource\": {\n\
+    \        \"type\": \"prometheus\",\n        \"uid\": \"Mimir\"\n      },\n      \"fieldConfig\": {\n\
+    \        \"defaults\": {\n          \"custom\": {\n            \"align\": \"auto\"\n          }\n\
+    \        },\n        \"overrides\": [\n          {\n            \"matcher\": {\n              \"id\"\
+    : \"byName\",\n              \"options\": \"Size\"\n            },\n            \"properties\": [\n\
+    \              {\n                \"id\": \"unit\",\n                \"value\": \"bytes\"\n      \
+    \        }\n            ]\n          },\n          {\n            \"matcher\": {\n              \"\
+    id\": \"byName\",\n              \"options\": \"Available\"\n            },\n            \"properties\"\
+    : [\n              {\n                \"id\": \"unit\",\n                \"value\": \"bytes\"\n  \
+    \            }\n            ]\n          },\n          {\n            \"matcher\": {\n           \
+    \   \"id\": \"byName\",\n              \"options\": \"Used\"\n            },\n            \"properties\"\
+    : [\n              {\n                \"id\": \"unit\",\n                \"value\": \"bytes\"\n  \
+    \            }\n            ]\n          },\n          {\n            \"matcher\": {\n           \
+    \   \"id\": \"byName\",\n              \"options\": \"Used %\"\n            },\n            \"properties\"\
+    : [\n              {\n                \"id\": \"unit\",\n                \"value\": \"percent\"\n\
+    \              },\n              {\n                \"id\": \"custom.cellOptions\",\n            \
+    \    \"value\": {\n                  \"type\": \"gauge\",\n                  \"mode\": \"gradient\"\
+    \n                }\n              },\n              {\n                \"id\": \"max\",\n       \
+    \         \"value\": 100\n              },\n              {\n                \"id\": \"min\",\n  \
+    \              \"value\": 0\n              },\n              {\n                \"id\": \"thresholds\"\
+    ,\n                \"value\": {\n                  \"mode\": \"absolute\",\n                  \"steps\"\
+    : [\n                    {\n                      \"color\": \"green\",\n                      \"\
+    value\": null\n                    },\n                    {\n                      \"color\": \"\
+    yellow\",\n                      \"value\": 75\n                    },\n                    {\n  \
+    \                    \"color\": \"red\",\n                      \"value\": 90\n                  \
+    \  }\n                  ]\n                }\n              }\n            ]\n          }\n      \
+    \  ]\n      },\n      \"gridPos\": {\n        \"h\": 12,\n        \"w\": 24,\n        \"x\": 0,\n\
+    \        \"y\": 13\n      },\n      \"id\": 6,\n      \"options\": {\n        \"showHeader\": true,\n\
+    \        \"sortBy\": [\n          {\n            \"desc\": true,\n            \"displayName\": \"\
+    Used %\"\n          }\n        ]\n      },\n      \"targets\": [\n        {\n          \"datasource\"\
+    : {\n            \"type\": \"prometheus\",\n            \"uid\": \"Mimir\"\n          },\n       \
+    \   \"expr\": \"node_filesystem_size_bytes{cluster=~\\\"$cluster\\\", instance=~\\\"$node\\\", fstype!~\\\
+    \"tmpfs|overlay|squashfs|ramfs|iso9660|autofs|devtmpfs\\\", mountpoint!~\\\"/(run|var/lib/kubelet|boot/efi).*\\\
+    \"}\",\n          \"format\": \"table\",\n          \"instant\": true,\n          \"refId\": \"Size\"\
+    \n        },\n        {\n          \"datasource\": {\n            \"type\": \"prometheus\",\n    \
+    \        \"uid\": \"Mimir\"\n          },\n          \"expr\": \"node_filesystem_avail_bytes{cluster=~\\\
+    \"$cluster\\\", instance=~\\\"$node\\\", fstype!~\\\"tmpfs|overlay|squashfs|ramfs|iso9660|autofs|devtmpfs\\\
+    \", mountpoint!~\\\"/(run|var/lib/kubelet|boot/efi).*\\\"}\",\n          \"format\": \"table\",\n\
+    \          \"instant\": true,\n          \"refId\": \"Available\"\n        },\n        {\n       \
+    \   \"datasource\": {\n            \"type\": \"prometheus\",\n            \"uid\": \"Mimir\"\n   \
+    \       },\n          \"expr\": \"node_filesystem_size_bytes{cluster=~\\\"$cluster\\\", instance=~\\\
+    \"$node\\\", fstype!~\\\"tmpfs|overlay|squashfs|ramfs|iso9660|autofs|devtmpfs\\\", mountpoint!~\\\"\
+    /(run|var/lib/kubelet|boot/efi).*\\\"} - node_filesystem_avail_bytes{cluster=~\\\"$cluster\\\", instance=~\\\
+    \"$node\\\", fstype!~\\\"tmpfs|overlay|squashfs|ramfs|iso9660|autofs|devtmpfs\\\", mountpoint!~\\\"\
+    /(run|var/lib/kubelet|boot/efi).*\\\"}\",\n          \"format\": \"table\",\n          \"instant\"\
+    : true,\n          \"refId\": \"Used\"\n        },\n        {\n          \"datasource\": {\n     \
+    \       \"type\": \"prometheus\",\n            \"uid\": \"Mimir\"\n          },\n          \"expr\"\
+    : \"(1 - node_filesystem_avail_bytes{cluster=~\\\"$cluster\\\", instance=~\\\"$node\\\", fstype!~\\\
+    \"tmpfs|overlay|squashfs|ramfs|iso9660|autofs|devtmpfs\\\", mountpoint!~\\\"/(run|var/lib/kubelet|boot/efi).*\\\
+    \"} / node_filesystem_size_bytes{cluster=~\\\"$cluster\\\", instance=~\\\"$node\\\", fstype!~\\\"\
+    tmpfs|overlay|squashfs|ramfs|iso9660|autofs|devtmpfs\\\", mountpoint!~\\\"/(run|var/lib/kubelet|boot/efi).*\\\
+    \"}) * 100\",\n          \"format\": \"table\",\n          \"instant\": true,\n          \"refId\"\
+    : \"Used %\"\n        }\n      ],\n      \"title\": \"Filesystem Inventory (per Node & Mountpoint)\"\
+    ,\n      \"type\": \"table\",\n      \"transformations\": [\n        {\n          \"id\": \"joinByField\"\
+    ,\n          \"options\": {\n            \"byField\": \"instance\",\n            \"mode\": \"outer\"\
+    \n          }\n        },\n        {\n          \"id\": \"organize\",\n          \"options\": {\n\
+    \            \"excludeByName\": {\n              \"Time\": true,\n              \"Time 1\": true,\n\
+    \              \"Time 2\": true,\n              \"Time 3\": true,\n              \"Time 4\": true,\n\
+    \              \"__name__\": true,\n              \"__name__ 1\": true,\n              \"__name__\
+    \ 2\": true,\n              \"__name__ 3\": true,\n              \"__name__ 4\": true,\n         \
+    \     \"job\": true,\n              \"job 1\": true,\n              \"job 2\": true,\n           \
+    \   \"job 3\": true,\n              \"job 4\": true,\n              \"endpoint\": true,\n        \
+    \      \"endpoint 1\": true,\n              \"endpoint 2\": true,\n              \"endpoint 3\": true,\n\
+    \              \"endpoint 4\": true,\n              \"container\": true,\n              \"container\
+    \ 1\": true,\n              \"container 2\": true,\n              \"container 3\": true,\n       \
+    \       \"container 4\": true,\n              \"namespace\": true,\n              \"namespace 1\"\
+    : true,\n              \"namespace 2\": true,\n              \"namespace 3\": true,\n            \
+    \  \"namespace 4\": true,\n              \"pod\": true,\n              \"pod 1\": true,\n        \
+    \      \"pod 2\": true,\n              \"pod 3\": true,\n              \"pod 4\": true,\n        \
+    \      \"service\": true,\n              \"service 1\": true,\n              \"service 2\": true,\n\
+    \              \"service 3\": true,\n              \"service 4\": true,\n              \"device 2\"\
+    : true,\n              \"device 3\": true,\n              \"device 4\": true,\n              \"fstype\
+    \ 2\": true,\n              \"fstype 3\": true,\n              \"fstype 4\": true,\n             \
+    \ \"mountpoint 2\": true,\n              \"mountpoint 3\": true,\n              \"mountpoint 4\":\
+    \ true,\n              \"cluster 2\": true,\n              \"cluster 3\": true,\n              \"\
+    cluster 4\": true\n            },\n            \"renameByName\": {\n              \"cluster 1\": \"\
+    Cluster\",\n              \"instance\": \"Node\",\n              \"device 1\": \"Device\",\n     \
+    \         \"fstype 1\": \"FS\",\n              \"mountpoint 1\": \"Mountpoint\",\n              \"\
+    Value #Size\": \"Size\",\n              \"Value #Available\": \"Available\",\n              \"Value\
+    \ #Used\": \"Used\",\n              \"Value #Used %\": \"Used %\"\n            }\n          }\n  \
+    \      }\n      ]\n    }\n  ],\n  \"templating\": {\n    \"list\": [\n      {\n        \"name\": \"\
+    cluster\",\n        \"label\": \"Cluster\",\n        \"type\": \"query\",\n        \"datasource\"\
+    : {\n          \"type\": \"prometheus\",\n          \"uid\": \"Mimir\"\n        },\n        \"query\"\
+    : \"label_values(node_filesystem_size_bytes, cluster)\",\n        \"refresh\": 2,\n        \"includeAll\"\
+    : true,\n        \"multi\": true,\n        \"current\": {\n          \"text\": \"All\",\n        \
+    \  \"value\": \"$__all\"\n        }\n      },\n      {\n        \"name\": \"node\",\n        \"label\"\
+    : \"Node\",\n        \"type\": \"query\",\n        \"datasource\": {\n          \"type\": \"prometheus\"\
+    ,\n          \"uid\": \"Mimir\"\n        },\n        \"query\": \"label_values(node_filesystem_size_bytes{cluster=~\\\
+    \"$cluster\\\"}, instance)\",\n        \"refresh\": 2,\n        \"includeAll\": true,\n        \"\
+    multi\": true,\n        \"current\": {\n          \"text\": \"All\",\n          \"value\": \"$__all\"\
+    \n        }\n      }\n    ]\n  }\n}"

--- a/infrastructure/grafana/dashboards/pvc-storage-dashboard.yaml
+++ b/infrastructure/grafana/dashboards/pvc-storage-dashboard.yaml
@@ -1,4 +1,3 @@
-# GrafanaDashboard — Comprehensive Cluster PVC Inventory & Absolute Capacity Details.
 apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDashboard
 metadata:
@@ -8,418 +7,212 @@ spec:
   allowCrossNamespaceImport: true
   instanceSelector:
     matchLabels:
-      dashboards: "grafana-central"
-  folder: "Storage & Persistent Volumes"
-  json: |
-    {
-      "annotations": {
-        "list": []
-      },
-      "editable": true,
-      "fiscalYearStartMonth": 0,
-      "graphTooltip": 1,
-      "id": null,
-      "links": [],
-      "liveNow": false,
-      "panels": [
-        {
-          "collapsed": false,
-          "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
-          "id": 1,
-          "title": "Global Storage Totals",
-          "type": "row"
-        },
-        {
-          "datasource": { "type": "prometheus", "uid": "Mimir" },
-          "fieldConfig": {
-            "defaults": {
-              "color": { "mode": "thresholds" },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  { "color": "blue", "value": null }
-                ]
-              },
-              "unit": "short"
-            }
-          },
-          "gridPos": { "h": 4, "w": 6, "x": 0, "y": 1 },
-          "id": 2,
-          "options": {
-            "colorMode": "value",
-            "graphMode": "area",
-            "justifyMode": "auto",
-            "orientation": "auto",
-            "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
-            "textMode": "auto"
-          },
-          "targets": [
-            {
-              "datasource": { "type": "prometheus", "uid": "Mimir" },
-              "expr": "count(kube_persistentvolumeclaim_info{cluster=~\"$cluster\", namespace=~\"$namespace\"})",
-              "legendFormat": "Total PVCs",
-              "refId": "A"
-            }
-          ],
-          "title": "Total PVC Count",
-          "type": "stat"
-        },
-        {
-          "datasource": { "type": "prometheus", "uid": "Mimir" },
-          "fieldConfig": {
-            "defaults": {
-              "color": { "mode": "thresholds" },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  { "color": "purple", "value": null }
-                ]
-              },
-              "unit": "bytes"
-            }
-          },
-          "gridPos": { "h": 4, "w": 6, "x": 6, "y": 1 },
-          "id": 3,
-          "options": {
-            "colorMode": "value",
-            "graphMode": "area",
-            "justifyMode": "auto",
-            "orientation": "auto",
-            "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
-            "textMode": "auto"
-          },
-          "targets": [
-            {
-              "datasource": { "type": "prometheus", "uid": "Mimir" },
-              "expr": "sum(kubelet_volume_stats_capacity_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\"})",
-              "legendFormat": "Max Capacity",
-              "refId": "A"
-            }
-          ],
-          "title": "Total Max Capacity",
-          "type": "stat"
-        },
-        {
-          "datasource": { "type": "prometheus", "uid": "Mimir" },
-          "fieldConfig": {
-            "defaults": {
-              "color": { "mode": "thresholds" },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  { "color": "orange", "value": null }
-                ]
-              },
-              "unit": "bytes"
-            }
-          },
-          "gridPos": { "h": 4, "w": 6, "x": 12, "y": 1 },
-          "id": 4,
-          "options": {
-            "colorMode": "value",
-            "graphMode": "area",
-            "justifyMode": "auto",
-            "orientation": "auto",
-            "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
-            "textMode": "auto"
-          },
-          "targets": [
-            {
-              "datasource": { "type": "prometheus", "uid": "Mimir" },
-              "expr": "sum(kubelet_volume_stats_used_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\"})",
-              "legendFormat": "Space Used",
-              "refId": "A"
-            }
-          ],
-          "title": "Total Space Used",
-          "type": "stat"
-        },
-        {
-          "datasource": { "type": "prometheus", "uid": "Mimir" },
-          "fieldConfig": {
-            "defaults": {
-              "color": { "mode": "thresholds" },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  { "color": "green", "value": null }
-                ]
-              },
-              "unit": "bytes"
-            }
-          },
-          "gridPos": { "h": 4, "w": 6, "x": 18, "y": 1 },
-          "id": 5,
-          "options": {
-            "colorMode": "value",
-            "graphMode": "area",
-            "justifyMode": "auto",
-            "orientation": "auto",
-            "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
-            "textMode": "auto"
-          },
-          "targets": [
-            {
-              "datasource": { "type": "prometheus", "uid": "Mimir" },
-              "expr": "sum(kubelet_volume_stats_available_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\"})",
-              "legendFormat": "Space Available",
-              "refId": "A"
-            }
-          ],
-          "title": "Total Free Space Available",
-          "type": "stat"
-        },
-        {
-          "collapsed": false,
-          "gridPos": { "h": 1, "w": 24, "x": 0, "y": 5 },
-          "id": 6,
-          "title": "Full PVC Listing (Capacity vs Used vs Free)",
-          "type": "row"
-        },
-        {
-          "datasource": { "type": "prometheus", "uid": "Mimir" },
-          "fieldConfig": {
-            "defaults": {
-              "custom": {
-                "align": "auto",
-                "cellOptions": { "type": "auto" },
-                "inspect": true
-              }
-            },
-            "overrides": [
-              {
-                "matcher": { "id": "byName", "options": "Max Capacity" },
-                "properties": [
-                  { "id": "unit", "value": "bytes" }
-                ]
-              },
-              {
-                "matcher": { "id": "byName", "options": "Used Space" },
-                "properties": [
-                  { "id": "unit", "value": "bytes" }
-                ]
-              },
-              {
-                "matcher": { "id": "byName", "options": "Available Space" },
-                "properties": [
-                  { "id": "unit", "value": "bytes" }
-                ]
-              },
-              {
-                "matcher": { "id": "byName", "options": "Usage Gauge" },
-                "properties": [
-                  { "id": "unit", "value": "percent" },
-                  { "id": "custom.cellOptions", "value": { "mode": "basic", "type": "gauge" } },
-                  {
-                    "id": "thresholds",
-                    "value": {
-                      "mode": "absolute",
-                      "steps": [
-                        { "color": "green", "value": null },
-                        { "color": "yellow", "value": 70 },
-                        { "color": "red", "value": 85 }
-                      ]
-                    }
-                  }
-                ]
-              }
-            ]
-          },
-          "gridPos": { "h": 14, "w": 24, "x": 0, "y": 6 },
-          "id": 7,
-          "options": {
-            "footer": { "countRows": true, "fields": "", "reducer": ["sum"], "show": true },
-            "showHeader": true,
-            "sortBy": [{ "desc": true, "displayName": "Used Space" }]
-          },
-          "targets": [
-            {
-              "datasource": { "type": "prometheus", "uid": "Mimir" },
-              "expr": "kubelet_volume_stats_capacity_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\"}",
-              "format": "table",
-              "instant": true,
-              "legendFormat": "",
-              "refId": "Capacity"
-            },
-            {
-              "datasource": { "type": "prometheus", "uid": "Mimir" },
-              "expr": "kubelet_volume_stats_used_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\"}",
-              "format": "table",
-              "instant": true,
-              "legendFormat": "",
-              "refId": "Used Space"
-            },
-            {
-              "datasource": { "type": "prometheus", "uid": "Mimir" },
-              "expr": "kubelet_volume_stats_available_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\"}",
-              "format": "table",
-              "instant": true,
-              "legendFormat": "",
-              "refId": "Available Space"
-            },
-            {
-              "datasource": { "type": "prometheus", "uid": "Mimir" },
-              "expr": "(kubelet_volume_stats_used_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\"} / kubelet_volume_stats_capacity_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\"}) * 100",
-              "format": "table",
-              "instant": true,
-              "legendFormat": "",
-              "refId": "Usage Gauge"
-            },
-            {
-              "datasource": { "type": "prometheus", "uid": "Mimir" },
-              "expr": "kube_persistentvolumeclaim_resource_requests_storage_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\"}",
-              "format": "table",
-              "instant": true,
-              "legendFormat": "",
-              "refId": "Requested"
-            }
-          ],
-          "title": "Complete PVC Inventory Listing (All Clusters & Namespaces)",
-          "transformations": [
-            {
-              "id": "seriesToColumns",
-              "options": {
-                "byField": "persistentvolumeclaim"
-              }
-            },
-            {
-              "id": "organize",
-              "options": {
-                "excludeByName": {
-                  "Time": true,
-                  "Time 1": true,
-                  "Time 2": true,
-                  "Time 3": true,
-                  "__name__": true,
-                  "endpoint": true,
-                  "job": true,
-                  "metrics_path": true,
-                  "service": true
-                },
-                "indexByName": {},
-                "renameByName": {
-                  "Value #Capacity": "Max Capacity",
-                  "Value #Used Space": "Used Space",
-                  "Value #Available Space": "Available Space",
-                  "Value #Usage Gauge": "Usage Gauge",
-                  "cluster": "Cluster",
-                  "namespace": "Namespace",
-                  "persistentvolumeclaim": "PVC Name"
-                }
-              }
-            }
-          ],
-          "type": "table"
-        },
-        {
-          "collapsed": false,
-          "gridPos": { "h": 1, "w": 24, "x": 0, "y": 20 },
-          "id": 8,
-          "title": "Volume Capacity vs Used Storage (In Bytes / GB)",
-          "type": "row"
-        },
-        {
-          "datasource": { "type": "prometheus", "uid": "Mimir" },
-          "fieldConfig": {
-            "defaults": {
-              "color": { "mode": "palette-classic" },
-              "custom": {
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "fillOpacity": 80,
-                "gradientMode": "none",
-                "hideFrom": { "legend": false, "tooltip": false, "viz": false },
-                "lineWidth": 1
-              },
-              "unit": "bytes"
-            }
-          },
-          "gridPos": { "h": 10, "w": 24, "x": 0, "y": 21 },
-          "id": 9,
-          "options": {
-            "barGroupMode": "stack",
-            "legend": { "displayMode": "table", "placement": "bottom" },
-            "orientation": "horizontal",
-            "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
-            "showValue": "auto",
-            "stacking": "none",
-            "tooltip": { "mode": "multi" }
-          },
-          "targets": [
-            {
-              "datasource": { "type": "prometheus", "uid": "Mimir" },
-              "expr": "kubelet_volume_stats_capacity_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\"}",
-              "legendFormat": "Max Capacity - {{cluster}} | {{namespace}}/{{persistentvolumeclaim}}",
-              "refId": "Capacity"
-            },
-            {
-              "datasource": { "type": "prometheus", "uid": "Mimir" },
-              "expr": "kubelet_volume_stats_used_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\"}",
-              "legendFormat": "Used - {{cluster}} | {{namespace}}/{{persistentvolumeclaim}}",
-              "refId": "Used"
-            }
-          ],
-          "title": "Max Capacity vs Real Disk Used per PVC",
-          "type": "barchart"
-        }
-      ],
-      "refresh": "30s",
-      "schemaVersion": 38,
-      "style": "dark",
-      "tags": ["storage", "pvc", "inventory", "capacity"],
-      "templating": {
-        "list": [
-          {
-            "allValue": ".*",
-            "current": { "selected": true, "text": "All", "value": "$__all" },
-            "datasource": { "type": "prometheus", "uid": "Mimir" },
-            "definition": "label_values(kubelet_volume_stats_capacity_bytes, cluster)",
-            "includeAll": true,
-            "label": "Cluster Filter",
-            "multi": true,
-            "name": "cluster",
-            "options": [],
-            "query": {
-              "query": "label_values(kubelet_volume_stats_capacity_bytes, cluster)",
-              "refId": "StandardVariableQuery"
-            },
-            "refresh": 1,
-            "regex": "",
-            "skipUrlSync": false,
-            "sort": 1,
-            "type": "query"
-          },
-          {
-            "allValue": ".*",
-            "current": { "selected": true, "text": "All", "value": "$__all" },
-            "datasource": { "type": "prometheus", "uid": "Mimir" },
-            "definition": "label_values(kubelet_volume_stats_capacity_bytes{cluster=~\"$cluster\"}, namespace)",
-            "includeAll": true,
-            "label": "Namespace Filter",
-            "multi": true,
-            "name": "namespace",
-            "options": [],
-            "query": {
-              "query": "label_values(kubelet_volume_stats_capacity_bytes{cluster=~\"$cluster\"}, namespace)",
-              "refId": "StandardVariableQuery"
-            },
-            "refresh": 1,
-            "regex": "",
-            "skipUrlSync": false,
-            "sort": 1,
-            "type": "query"
-          }
-        ]
-      },
-      "time": { "from": "now-1h", "to": "now" },
-      "timepicker": { "refresh_intervals": ["5s", "10s", "30s", "1m", "5m"] },
-      "timezone": "browser",
-      "title": "Cluster PVC Inventory & Detailed Storage Capacity",
-      "uid": "cluster-pvc-storage-overview"
-    }
+      dashboards: grafana-central
+  folder: Storage & Persistent Volumes
+  json:
+    "{\n  \"annotations\": {\n    \"list\": []\n  },\n  \"editable\": true,\n  \"fiscalYearStartMonth\"\
+    : 0,\n  \"graphTooltip\": 1,\n  \"id\": null,\n  \"links\": [],\n  \"liveNow\": false,\n  \"panels\"\
+    : [\n    {\n      \"collapsed\": false,\n      \"gridPos\": {\n        \"h\": 1,\n        \"w\": 24,\n\
+    \        \"x\": 0,\n        \"y\": 0\n      },\n      \"id\": 1,\n      \"title\": \"Global Storage\
+    \ Totals\",\n      \"type\": \"row\"\n    },\n    {\n      \"datasource\": {\n        \"type\": \"\
+    prometheus\",\n        \"uid\": \"Mimir\"\n      },\n      \"fieldConfig\": {\n        \"defaults\"\
+    : {\n          \"color\": {\n            \"mode\": \"thresholds\"\n          },\n          \"mappings\"\
+    : [],\n          \"thresholds\": {\n            \"mode\": \"absolute\",\n            \"steps\": [\n\
+    \              {\n                \"color\": \"blue\",\n                \"value\": null\n        \
+    \      }\n            ]\n          },\n          \"unit\": \"short\"\n        }\n      },\n      \"\
+    gridPos\": {\n        \"h\": 4,\n        \"w\": 6,\n        \"x\": 0,\n        \"y\": 1\n      },\n\
+    \      \"id\": 2,\n      \"options\": {\n        \"colorMode\": \"value\",\n        \"graphMode\"\
+    : \"area\",\n        \"justifyMode\": \"auto\",\n        \"orientation\": \"auto\",\n        \"reduceOptions\"\
+    : {\n          \"calcs\": [\n            \"lastNotNull\"\n          ],\n          \"fields\": \"\"\
+    ,\n          \"values\": false\n        },\n        \"textMode\": \"auto\"\n      },\n      \"targets\"\
+    : [\n        {\n          \"datasource\": {\n            \"type\": \"prometheus\",\n            \"\
+    uid\": \"Mimir\"\n          },\n          \"expr\": \"count(kube_persistentvolumeclaim_info{cluster=~\\\
+    \"$cluster\\\", namespace=~\\\"$namespace\\\"})\",\n          \"legendFormat\": \"Total PVCs\",\n\
+    \          \"refId\": \"A\"\n        }\n      ],\n      \"title\": \"Total PVC Count\",\n      \"\
+    type\": \"stat\"\n    },\n    {\n      \"datasource\": {\n        \"type\": \"prometheus\",\n    \
+    \    \"uid\": \"Mimir\"\n      },\n      \"fieldConfig\": {\n        \"defaults\": {\n          \"\
+    color\": {\n            \"mode\": \"thresholds\"\n          },\n          \"mappings\": [],\n    \
+    \      \"thresholds\": {\n            \"mode\": \"absolute\",\n            \"steps\": [\n        \
+    \      {\n                \"color\": \"purple\",\n                \"value\": null\n              }\n\
+    \            ]\n          },\n          \"unit\": \"bytes\"\n        }\n      },\n      \"gridPos\"\
+    : {\n        \"h\": 4,\n        \"w\": 6,\n        \"x\": 6,\n        \"y\": 1\n      },\n      \"\
+    id\": 3,\n      \"options\": {\n        \"colorMode\": \"value\",\n        \"graphMode\": \"area\"\
+    ,\n        \"justifyMode\": \"auto\",\n        \"orientation\": \"auto\",\n        \"reduceOptions\"\
+    : {\n          \"calcs\": [\n            \"lastNotNull\"\n          ],\n          \"fields\": \"\"\
+    ,\n          \"values\": false\n        },\n        \"textMode\": \"auto\"\n      },\n      \"targets\"\
+    : [\n        {\n          \"datasource\": {\n            \"type\": \"prometheus\",\n            \"\
+    uid\": \"Mimir\"\n          },\n          \"expr\": \"sum(kube_persistentvolumeclaim_resource_requests_storage_bytes{cluster=~\\\
+    \"$cluster\\\", namespace=~\\\"$namespace\\\"})\",\n          \"legendFormat\": \"Max Capacity\",\n\
+    \          \"refId\": \"A\"\n        }\n      ],\n      \"title\": \"Total Max Capacity\",\n     \
+    \ \"type\": \"stat\"\n    },\n    {\n      \"datasource\": {\n        \"type\": \"prometheus\",\n\
+    \        \"uid\": \"Mimir\"\n      },\n      \"fieldConfig\": {\n        \"defaults\": {\n       \
+    \   \"color\": {\n            \"mode\": \"thresholds\"\n          },\n          \"mappings\": [],\n\
+    \          \"thresholds\": {\n            \"mode\": \"absolute\",\n            \"steps\": [\n    \
+    \          {\n                \"color\": \"orange\",\n                \"value\": null\n          \
+    \    }\n            ]\n          },\n          \"unit\": \"bytes\"\n        }\n      },\n      \"\
+    gridPos\": {\n        \"h\": 4,\n        \"w\": 6,\n        \"x\": 12,\n        \"y\": 1\n      },\n\
+    \      \"id\": 4,\n      \"options\": {\n        \"colorMode\": \"value\",\n        \"graphMode\"\
+    : \"area\",\n        \"justifyMode\": \"auto\",\n        \"orientation\": \"auto\",\n        \"reduceOptions\"\
+    : {\n          \"calcs\": [\n            \"lastNotNull\"\n          ],\n          \"fields\": \"\"\
+    ,\n          \"values\": false\n        },\n        \"textMode\": \"auto\"\n      },\n      \"targets\"\
+    : [\n        {\n          \"datasource\": {\n            \"type\": \"prometheus\",\n            \"\
+    uid\": \"Mimir\"\n          },\n          \"expr\": \"sum(max by (cluster, namespace, persistentvolumeclaim)\
+    \ (kubelet_volume_stats_used_bytes{cluster=~\\\"$cluster\\\", namespace=~\\\"$namespace\\\"}))\",\n\
+    \          \"legendFormat\": \"Space Used\",\n          \"refId\": \"A\"\n        }\n      ],\n  \
+    \    \"title\": \"Total Space Used\",\n      \"type\": \"stat\"\n    },\n    {\n      \"datasource\"\
+    : {\n        \"type\": \"prometheus\",\n        \"uid\": \"Mimir\"\n      },\n      \"fieldConfig\"\
+    : {\n        \"defaults\": {\n          \"color\": {\n            \"mode\": \"thresholds\"\n     \
+    \     },\n          \"mappings\": [],\n          \"thresholds\": {\n            \"mode\": \"absolute\"\
+    ,\n            \"steps\": [\n              {\n                \"color\": \"green\",\n            \
+    \    \"value\": null\n              }\n            ]\n          },\n          \"unit\": \"bytes\"\n\
+    \        }\n      },\n      \"gridPos\": {\n        \"h\": 4,\n        \"w\": 6,\n        \"x\": 18,\n\
+    \        \"y\": 1\n      },\n      \"id\": 5,\n      \"options\": {\n        \"colorMode\": \"value\"\
+    ,\n        \"graphMode\": \"area\",\n        \"justifyMode\": \"auto\",\n        \"orientation\":\
+    \ \"auto\",\n        \"reduceOptions\": {\n          \"calcs\": [\n            \"lastNotNull\"\n \
+    \         ],\n          \"fields\": \"\",\n          \"values\": false\n        },\n        \"textMode\"\
+    : \"auto\"\n      },\n      \"targets\": [\n        {\n          \"datasource\": {\n            \"\
+    type\": \"prometheus\",\n            \"uid\": \"Mimir\"\n          },\n          \"expr\": \"sum(kube_persistentvolumeclaim_resource_requests_storage_bytes{cluster=~\\\
+    \"$cluster\\\", namespace=~\\\"$namespace\\\"}) - sum(max by (cluster, namespace, persistentvolumeclaim)\
+    \ (kubelet_volume_stats_used_bytes{cluster=~\\\"$cluster\\\", namespace=~\\\"$namespace\\\"}))\",\n\
+    \          \"legendFormat\": \"Space Available\",\n          \"refId\": \"A\"\n        }\n      ],\n\
+    \      \"title\": \"Total Free Space Available\",\n      \"type\": \"stat\"\n    },\n    {\n     \
+    \ \"collapsed\": false,\n      \"gridPos\": {\n        \"h\": 1,\n        \"w\": 24,\n        \"x\"\
+    : 0,\n        \"y\": 5\n      },\n      \"id\": 6,\n      \"title\": \"Full PVC Listing (Capacity\
+    \ vs Used vs Free)\",\n      \"type\": \"row\"\n    },\n    {\n      \"datasource\": {\n        \"\
+    type\": \"prometheus\",\n        \"uid\": \"Mimir\"\n      },\n      \"fieldConfig\": {\n        \"\
+    defaults\": {\n          \"custom\": {\n            \"align\": \"auto\",\n            \"cellOptions\"\
+    : {\n              \"type\": \"auto\"\n            },\n            \"inspect\": true\n          }\n\
+    \        },\n        \"overrides\": [\n          {\n            \"matcher\": {\n              \"id\"\
+    : \"byName\",\n              \"options\": \"Max Capacity\"\n            },\n            \"properties\"\
+    : [\n              {\n                \"id\": \"unit\",\n                \"value\": \"bytes\"\n  \
+    \            }\n            ]\n          },\n          {\n            \"matcher\": {\n           \
+    \   \"id\": \"byName\",\n              \"options\": \"Used Space\"\n            },\n            \"\
+    properties\": [\n              {\n                \"id\": \"unit\",\n                \"value\": \"\
+    bytes\"\n              }\n            ]\n          },\n          {\n            \"matcher\": {\n \
+    \             \"id\": \"byName\",\n              \"options\": \"Available Space\"\n            },\n\
+    \            \"properties\": [\n              {\n                \"id\": \"unit\",\n             \
+    \   \"value\": \"bytes\"\n              }\n            ]\n          },\n          {\n            \"\
+    matcher\": {\n              \"id\": \"byName\",\n              \"options\": \"Usage Gauge\"\n    \
+    \        },\n            \"properties\": [\n              {\n                \"id\": \"unit\",\n \
+    \               \"value\": \"percent\"\n              },\n              {\n                \"id\"\
+    : \"custom.cellOptions\",\n                \"value\": {\n                  \"mode\": \"basic\",\n\
+    \                  \"type\": \"gauge\"\n                }\n              },\n              {\n   \
+    \             \"id\": \"thresholds\",\n                \"value\": {\n                  \"mode\": \"\
+    absolute\",\n                  \"steps\": [\n                    {\n                      \"color\"\
+    : \"green\",\n                      \"value\": null\n                    },\n                    {\n\
+    \                      \"color\": \"yellow\",\n                      \"value\": 70\n             \
+    \       },\n                    {\n                      \"color\": \"red\",\n                   \
+    \   \"value\": 85\n                    }\n                  ]\n                }\n              }\n\
+    \            ]\n          }\n        ]\n      },\n      \"gridPos\": {\n        \"h\": 14,\n     \
+    \   \"w\": 24,\n        \"x\": 0,\n        \"y\": 6\n      },\n      \"id\": 7,\n      \"options\"\
+    : {\n        \"footer\": {\n          \"countRows\": true,\n          \"fields\": \"\",\n        \
+    \  \"reducer\": [\n            \"sum\"\n          ],\n          \"show\": true\n        },\n     \
+    \   \"showHeader\": true,\n        \"sortBy\": [\n          {\n            \"desc\": true,\n     \
+    \       \"displayName\": \"Used Space\"\n          }\n        ]\n      },\n      \"targets\": [\n\
+    \        {\n          \"datasource\": {\n            \"type\": \"prometheus\",\n            \"uid\"\
+    : \"Mimir\"\n          },\n          \"expr\": \"kubelet_volume_stats_capacity_bytes{cluster=~\\\"\
+    $cluster\\\", namespace=~\\\"$namespace\\\"}\",\n          \"format\": \"table\",\n          \"instant\"\
+    : true,\n          \"legendFormat\": \"\",\n          \"refId\": \"Capacity\"\n        },\n      \
+    \  {\n          \"datasource\": {\n            \"type\": \"prometheus\",\n            \"uid\": \"\
+    Mimir\"\n          },\n          \"expr\": \"kubelet_volume_stats_used_bytes{cluster=~\\\"$cluster\\\
+    \", namespace=~\\\"$namespace\\\"}\",\n          \"format\": \"table\",\n          \"instant\": true,\n\
+    \          \"legendFormat\": \"\",\n          \"refId\": \"Used Space\"\n        },\n        {\n \
+    \         \"datasource\": {\n            \"type\": \"prometheus\",\n            \"uid\": \"Mimir\"\
+    \n          },\n          \"expr\": \"kubelet_volume_stats_available_bytes{cluster=~\\\"$cluster\\\
+    \", namespace=~\\\"$namespace\\\"}\",\n          \"format\": \"table\",\n          \"instant\": true,\n\
+    \          \"legendFormat\": \"\",\n          \"refId\": \"Available Space\"\n        },\n       \
+    \ {\n          \"datasource\": {\n            \"type\": \"prometheus\",\n            \"uid\": \"Mimir\"\
+    \n          },\n          \"expr\": \"(kubelet_volume_stats_used_bytes{cluster=~\\\"$cluster\\\",\
+    \ namespace=~\\\"$namespace\\\"} / kubelet_volume_stats_capacity_bytes{cluster=~\\\"$cluster\\\",\
+    \ namespace=~\\\"$namespace\\\"}) * 100\",\n          \"format\": \"table\",\n          \"instant\"\
+    : true,\n          \"legendFormat\": \"\",\n          \"refId\": \"Usage Gauge\"\n        },\n   \
+    \     {\n          \"datasource\": {\n            \"type\": \"prometheus\",\n            \"uid\":\
+    \ \"Mimir\"\n          },\n          \"expr\": \"kube_persistentvolumeclaim_resource_requests_storage_bytes{cluster=~\\\
+    \"$cluster\\\", namespace=~\\\"$namespace\\\"}\",\n          \"format\": \"table\",\n          \"\
+    instant\": true,\n          \"legendFormat\": \"\",\n          \"refId\": \"Requested\"\n        }\n\
+    \      ],\n      \"title\": \"Complete PVC Inventory Listing (All Clusters & Namespaces)\",\n    \
+    \  \"transformations\": [\n        {\n          \"id\": \"seriesToColumns\",\n          \"options\"\
+    : {\n            \"byField\": \"persistentvolumeclaim\"\n          }\n        },\n        {\n    \
+    \      \"id\": \"organize\",\n          \"options\": {\n            \"excludeByName\": {\n       \
+    \       \"Time\": true,\n              \"Time 1\": true,\n              \"Time 2\": true,\n      \
+    \        \"Time 3\": true,\n              \"__name__\": true,\n              \"endpoint\": true,\n\
+    \              \"job\": true,\n              \"metrics_path\": true,\n              \"service\": true\n\
+    \            },\n            \"indexByName\": {},\n            \"renameByName\": {\n             \
+    \ \"Value #Capacity\": \"Max Capacity\",\n              \"Value #Used Space\": \"Used Space\",\n \
+    \             \"Value #Available Space\": \"Available Space\",\n              \"Value #Usage Gauge\"\
+    : \"Usage Gauge\",\n              \"cluster\": \"Cluster\",\n              \"namespace\": \"Namespace\"\
+    ,\n              \"persistentvolumeclaim\": \"PVC Name\"\n            }\n          }\n        }\n\
+    \      ],\n      \"type\": \"table\"\n    },\n    {\n      \"collapsed\": false,\n      \"gridPos\"\
+    : {\n        \"h\": 1,\n        \"w\": 24,\n        \"x\": 0,\n        \"y\": 20\n      },\n     \
+    \ \"id\": 8,\n      \"title\": \"Volume Capacity vs Used Storage (In Bytes / GB)\",\n      \"type\"\
+    : \"row\"\n    },\n    {\n      \"datasource\": {\n        \"type\": \"prometheus\",\n        \"uid\"\
+    : \"Mimir\"\n      },\n      \"fieldConfig\": {\n        \"defaults\": {\n          \"color\": {\n\
+    \            \"mode\": \"palette-classic\"\n          },\n          \"custom\": {\n            \"\
+    axisCenteredZero\": false,\n            \"axisColorMode\": \"text\",\n            \"axisLabel\": \"\
+    \",\n            \"axisPlacement\": \"auto\",\n            \"fillOpacity\": 80,\n            \"gradientMode\"\
+    : \"none\",\n            \"hideFrom\": {\n              \"legend\": false,\n              \"tooltip\"\
+    : false,\n              \"viz\": false\n            },\n            \"lineWidth\": 1\n          },\n\
+    \          \"unit\": \"bytes\"\n        }\n      },\n      \"gridPos\": {\n        \"h\": 10,\n  \
+    \      \"w\": 24,\n        \"x\": 0,\n        \"y\": 21\n      },\n      \"id\": 9,\n      \"options\"\
+    : {\n        \"barGroupMode\": \"stack\",\n        \"legend\": {\n          \"displayMode\": \"table\"\
+    ,\n          \"placement\": \"bottom\"\n        },\n        \"orientation\": \"horizontal\",\n   \
+    \     \"reduceOptions\": {\n          \"calcs\": [\n            \"lastNotNull\"\n          ],\n  \
+    \        \"fields\": \"\",\n          \"values\": false\n        },\n        \"showValue\": \"auto\"\
+    ,\n        \"stacking\": \"none\",\n        \"tooltip\": {\n          \"mode\": \"multi\"\n      \
+    \  }\n      },\n      \"targets\": [\n        {\n          \"datasource\": {\n            \"type\"\
+    : \"prometheus\",\n            \"uid\": \"Mimir\"\n          },\n          \"expr\": \"kubelet_volume_stats_capacity_bytes{cluster=~\\\
+    \"$cluster\\\", namespace=~\\\"$namespace\\\"}\",\n          \"legendFormat\": \"Max Capacity - {{cluster}}\
+    \ | {{namespace}}/{{persistentvolumeclaim}}\",\n          \"refId\": \"Capacity\"\n        },\n  \
+    \      {\n          \"datasource\": {\n            \"type\": \"prometheus\",\n            \"uid\"\
+    : \"Mimir\"\n          },\n          \"expr\": \"kubelet_volume_stats_used_bytes{cluster=~\\\"$cluster\\\
+    \", namespace=~\\\"$namespace\\\"}\",\n          \"legendFormat\": \"Used - {{cluster}} | {{namespace}}/{{persistentvolumeclaim}}\"\
+    ,\n          \"refId\": \"Used\"\n        }\n      ],\n      \"title\": \"Max Capacity vs Real Disk\
+    \ Used per PVC\",\n      \"type\": \"barchart\"\n    },\n    {\n      \"datasource\": {\n        \"\
+    type\": \"prometheus\",\n        \"uid\": \"Mimir\"\n      },\n      \"description\": \"Per-PVC fill\
+    \ level: used / capacity as reported by the kubelet. Red at 90%, amber at 75%. NOTE for RWX volumes\
+    \ backed by the shared CephFS NFS export, BOTH used and capacity are statfs() on the whole export,\
+    \ so the figure is the export's fill level rather than that single claim's.\",\n      \"fieldConfig\"\
+    : {\n        \"defaults\": {\n          \"unit\": \"percent\",\n          \"min\": 0,\n          \"\
+    max\": 100,\n          \"color\": {\n            \"mode\": \"thresholds\"\n          },\n        \
+    \  \"thresholds\": {\n            \"mode\": \"absolute\",\n            \"steps\": [\n            \
+    \  {\n                \"color\": \"green\",\n                \"value\": null\n              },\n \
+    \             {\n                \"color\": \"#EAB839\",\n                \"value\": 75\n        \
+    \      },\n              {\n                \"color\": \"red\",\n                \"value\": 90\n \
+    \             }\n            ]\n          }\n        },\n        \"overrides\": []\n      },\n   \
+    \   \"gridPos\": {\n        \"h\": 9,\n        \"w\": 24,\n        \"x\": 0,\n        \"y\": 31\n\
+    \      },\n      \"id\": 10,\n      \"options\": {\n        \"displayMode\": \"gradient\",\n     \
+    \   \"minVizHeight\": 18,\n        \"minVizWidth\": 8,\n        \"orientation\": \"horizontal\",\n\
+    \        \"showUnfilled\": true,\n        \"reduceOptions\": {\n          \"calcs\": [\n         \
+    \   \"lastNotNull\"\n          ],\n          \"fields\": \"\",\n          \"values\": false\n    \
+    \    },\n        \"valueMode\": \"color\",\n        \"namePlacement\": \"left\",\n        \"sizing\"\
+    : \"auto\"\n      },\n      \"pluginVersion\": \"11.0.0\",\n      \"targets\": [\n        {\n    \
+    \      \"datasource\": {\n            \"type\": \"prometheus\",\n            \"uid\": \"Mimir\"\n\
+    \          },\n          \"expr\": \"100 * (kubelet_volume_stats_used_bytes{cluster=~\\\"$cluster\\\
+    \", namespace=~\\\"$namespace\\\"} / kubelet_volume_stats_capacity_bytes{cluster=~\\\"$cluster\\\"\
+    , namespace=~\\\"$namespace\\\"})\",\n          \"instant\": true,\n          \"legendFormat\": \"\
+    {{cluster}} / {{namespace}} / {{persistentvolumeclaim}}\",\n          \"refId\": \"A\"\n        }\n\
+    \      ],\n      \"title\": \"PVC Fill Level - Used vs Capacity (red >90%, amber >75%)\",\n      \"\
+    type\": \"bargauge\"\n    }\n  ],\n  \"refresh\": \"30s\",\n  \"schemaVersion\": 38,\n  \"style\"\
+    : \"dark\",\n  \"tags\": [\n    \"storage\",\n    \"pvc\",\n    \"inventory\",\n    \"capacity\"\n\
+    \  ],\n  \"templating\": {\n    \"list\": [\n      {\n        \"allValue\": \".*\",\n        \"current\"\
+    : {\n          \"selected\": true,\n          \"text\": \"All\",\n          \"value\": \"$__all\"\n\
+    \        },\n        \"datasource\": {\n          \"type\": \"prometheus\",\n          \"uid\": \"\
+    Mimir\"\n        },\n        \"definition\": \"label_values(kubelet_volume_stats_capacity_bytes, cluster)\"\
+    ,\n        \"includeAll\": true,\n        \"label\": \"Cluster Filter\",\n        \"multi\": true,\n\
+    \        \"name\": \"cluster\",\n        \"options\": [],\n        \"query\": {\n          \"query\"\
+    : \"label_values(kubelet_volume_stats_capacity_bytes, cluster)\",\n          \"refId\": \"StandardVariableQuery\"\
+    \n        },\n        \"refresh\": 1,\n        \"regex\": \"\",\n        \"skipUrlSync\": false,\n\
+    \        \"sort\": 1,\n        \"type\": \"query\"\n      },\n      {\n        \"allValue\": \".*\"\
+    ,\n        \"current\": {\n          \"selected\": true,\n          \"text\": \"All\",\n         \
+    \ \"value\": \"$__all\"\n        },\n        \"datasource\": {\n          \"type\": \"prometheus\"\
+    ,\n          \"uid\": \"Mimir\"\n        },\n        \"definition\": \"label_values(kubelet_volume_stats_capacity_bytes{cluster=~\\\
+    \"$cluster\\\"}, namespace)\",\n        \"includeAll\": true,\n        \"label\": \"Namespace Filter\"\
+    ,\n        \"multi\": true,\n        \"name\": \"namespace\",\n        \"options\": [],\n        \"\
+    query\": {\n          \"query\": \"label_values(kubelet_volume_stats_capacity_bytes{cluster=~\\\"\
+    $cluster\\\"}, namespace)\",\n          \"refId\": \"StandardVariableQuery\"\n        },\n       \
+    \ \"refresh\": 1,\n        \"regex\": \"\",\n        \"skipUrlSync\": false,\n        \"sort\": 1,\n\
+    \        \"type\": \"query\"\n      }\n    ]\n  },\n  \"time\": {\n    \"from\": \"now-1h\",\n   \
+    \ \"to\": \"now\"\n  },\n  \"timepicker\": {\n    \"refresh_intervals\": [\n      \"5s\",\n      \"\
+    10s\",\n      \"30s\",\n      \"1m\",\n      \"5m\"\n    ]\n  },\n  \"timezone\": \"browser\",\n \
+    \ \"title\": \"Cluster PVC Inventory & Detailed Storage Capacity\",\n  \"uid\": \"cluster-pvc-storage-overview\"\
+    \n}"

--- a/infrastructure/grafana/kustomization.yaml
+++ b/infrastructure/grafana/kustomization.yaml
@@ -4,4 +4,5 @@ resources:
   - mimir-datasource.yaml
   - dashboards/cluster-overview-dashboard.yaml
   - dashboards/pvc-storage-dashboard.yaml
+  - dashboards/node-filesystem-dashboard.yaml
   - httproute.yaml


### PR DESCRIPTION
## The 4TB-vs-2.8TiB mystery

Two errors compounding:

1. **"Total Max Capacity" summed `kubelet_volume_stats_capacity_bytes`**, which for an NFS-backed PV is a `statfs()` on the **whole export**, not the claim. Production's single `ceph-cephfs` PVC (requested **900Gi**) reported **~3.7 TiB**.
2. **Raw vs usable** — Ceph reports 2.8 TiB **RAW**; `rdb-pool` is `size: 2`, so usable is **~1.4 TiB**.

```
cluster=mgmt          75.7 GiB
cluster=production  3991.3 GiB   <- 1 NFS PVC reporting the whole export
real provisioned:   ~1131 GiB    (900Gi NFS + ~231Gi Cinder)
```

Fixes:
- max capacity -> `kube_persistentvolumeclaim_resource_requests_storage_bytes` (per claim, from KSM)
- used -> deduplicated via `max by (cluster, namespace, persistentvolumeclaim)`
- free -> `requested - used` rather than export-wide avail

## PVC fill gauge

Horizontal bargauge, per-PVC `used/capacity`, **amber >75% / red >90%**. Caveat is in the panel description: for RWX volumes on the shared CephFS NFS export both numbers are export-wide, so the bar shows the *export's* fill level.

## Node Filesystem / Hypervisor Storage dashboard

node-exporter driven (`node_filesystem_*`): size/used/available/used% stats, per-mountpoint usage timeseries, and a sortable inventory table with a gradient gauge column. Pseudo-filesystems and kubelet bind-mounts excluded so container mounts aren't double-counted. Now that the openstack cluster ships to the central Mimir this covers the baremetal hypervisors **lucy/makise/quinn**.