### PR TITLE
fix(prometheus-adapter): do not let Helm wait on the APIService

### DIFF
--- a/infrastructure/monitoring/prometheus-adapter.yaml
+++ b/infrastructure/monitoring/prometheus-adapter.yaml
@@ -27,6 +27,27 @@ spec:
         kind: HelmRepository
         name: prometheus-community
         namespace: monitoring
+  # Do NOT let Helm block on readiness here. The chart's APIService
+  # (v1beta1.metrics.k8s.io) only reports Available once the aggregation layer
+  # has successfully proxied to the adapter, which races the adapter's own
+  # startup: Helm times out waiting, Flux treats the install as failed and ROLLS
+  # BACK, deleting the very APIService it was waiting for. Observed symptom is a
+  # healthy 1/1 adapter Pod alongside
+  #   "timeout waiting for: [APIService/v1beta1.metrics.k8s.io status: 'NotFound']"
+  # and no metrics API at all. Worse, because the monitoring Kustomization
+  # health-checks its HelmReleases, that failure blocked the whole stack behind
+  # it (the Grafana dashboards stopped reconciling).
+  #
+  # Applying without waiting lets the APIService settle asynchronously, which is
+  # the normal pattern for aggregated API servers.
+  install:
+    disableWait: true
+    remediation:
+      retries: 3
+  upgrade:
+    disableWait: true
+    remediation:
+      retries: 3
   values:
     prometheus:
       url: http://kube-prometheus-stack-prometheus.monitoring.svc


### PR DESCRIPTION
Install kept failing with `timeout waiting for: [APIService/v1beta1.metrics.k8s.io status: 'NotFound']` while the adapter Pod was healthy at 1/1.

The APIService only reports `Available` once the aggregation layer has proxied to the adapter, which races the adapter's own startup. Helm times out, Flux treats the install as failed and **rolls back — deleting the APIService it was waiting for**, so it can never converge.

Because the `monitoring` Kustomization health-checks its HelmReleases, this also blocked everything behind it: the PVC fill gauge and node-filesystem dashboard were merged but never reconciled.

`disableWait` lets it settle asynchronously — the normal pattern for aggregated API servers.