### PR TITLE
fix(monitoring): add node label to node-exporter for prometheus-adapter

### DIFF
--- a/infrastructure/monitoring/helmrelease.yaml
+++ b/infrastructure/monitoring/helmrelease.yaml
@@ -188,6 +188,21 @@ spec:
     # --- Exporters ---
     nodeExporter:
       enabled: true
+      # prometheus-adapter needs a `node` label on node-exporter metrics to map
+      # Prometheus time-series to Kubernetes node names. node-exporter only emits
+      # `instance` (IP:port) and `nodename` (kernel hostname), not `node`. The
+      # kubelet SD meta label `__meta_kubernetes_pod_node_name` carries the
+      # Kubernetes node name and is available as a relabel source.
+      prometheus:
+        monitor:
+          relabelings:
+            - sourceLabels: [__meta_kubernetes_pod_node_name]
+              targetLabel: node
+            # Keep the chart's own metrics_path relabeling (the chart adds it
+            # by default but replaces it wholesale if we set relabelings).
+            - action: replace
+              sourceLabels: [__metrics_path__]
+              targetLabel: metrics_path
     kubeStateMetrics:
       enabled: true
       resources:


### PR DESCRIPTION
prometheus-adapter injects a node=xxx label matcher into its CPU/memory queries. node-exporter metrics have no node label — only instance (IP:port) and the kubelet SD meta label __meta_kubernetes_pod_node_name. Add a target relabeling to map that meta label to node, so kubectl top nodes / k9s resource panels work.

Verified: kubectl top nodes now shows all 6 nodes with correct CPU/memory.