### PR TITLE
refactor(capi): re-enable prune: true on cluster-api-templates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -474,10 +474,7 @@ cluster-api-templates`, which now runs `wait: true` — templates are statusless
   > CR is at `clusters/mgmt/clusters/mgmt.yaml` (`classRef.name: openstack-default-v1`).
   > MIGRATION NOTE: an in-use ClusterClass is protected from deletion by the CAPI
   > `validation.clusterclass.cluster.x-k8s.io` webhook (verified live), so a stray
-  > prune can't destroy `openstack-default`/`openstack-kamaji`; the split
-  > additionally set `cluster-api-templates` `prune: false` for ONE commit so the
-  > handoff dropped the classes from the old inventory WITHOUT deleting, then
-  > re-enabled `prune: true` once `cluster-api-clusterclasses` adopted them.
+  > prune can't destroy `openstack-default`/`openstack-kamaji`.
 
 - **capo-identity/** — ESO projects `capo-variables` (capo-system) →
   `mgmt/mgmt-cloud-config`. Split from templates for blast-radius isolation.
@@ -973,11 +970,10 @@ and dragged the valid templates down, retrying forever. Now `cluster-api-templat
 holds ONLY the versioned templates and runs `wait: true` (statusless CRs → Ready
 immediately); `cluster-api-clusterclasses` adopts them (`wait` omitted to avoid the
 topology-controller wedge); `clusters` now `dependsOn: cluster-api-clusterclasses`.
-Prune-safe handoff: `cluster-api-templates` was set `prune: false` for THIS commit
-only (so dropping the ClusterClasses from its inventory does NOT delete them; the
-new Kustomization adopts them in place via server-side apply, owner-label change
-only) and is flipped back to `prune: true` in the follow-up commit once adoption is
-confirmed. Backstop: the CAPI `validation.clusterclass.cluster.x-k8s.io` webhook
+Prune-safe handoff: `cluster-api-templates` was set `prune: false` for ONE commit
+(so dropping the ClusterClasses from its inventory did NOT delete them; the
+new Kustomization adopted them in place via server-side apply, owner-label change
+only) and is now restored to `prune: true`. Backstop: the CAPI `validation.clusterclass.cluster.x-k8s.io` webhook
 hard-refuses deletion of any in-use ClusterClass (verified live —
 `openstack-default`/`openstack-kamaji` can't be pruned while `mgmt`/`production`
 reference them). Prior substantive change: Wired the **capi-janitor** into the

--- a/clusters/mgmt/cluster-api-templates.yaml
+++ b/clusters/mgmt/cluster-api-templates.yaml
@@ -10,20 +10,7 @@ spec:
     name: flux-system
     namespace: flux-system
   path: ./infrastructure/cluster-api-templates
-  # MIGRATION (temporary): prune is set to false for the split-out commit ONLY.
-  # The 4 ClusterClasses used to live in THIS Kustomization's inventory; the split
-  # moves them to cluster-api-clusterclasses. On the reconcile that picks up the
-  # split, this Kustomization sees the ClusterClasses gone from its desired set —
-  # with prune: true it would DELETE them in that same reconcile, before the new
-  # Kustomization can adopt them (live Clusters reference them: mgmt →
-  # openstack-default, production → openstack-kamaji). prune: false makes it drop
-  # them from its inventory WITHOUT deleting; cluster-api-clusterclasses then
-  # adopts them in place via server-side apply (owner-label change only).
-  # RE-ENABLE prune: true in the NEXT commit once adoption is confirmed
-  # (kubectl get clusterclass -n mgmt -o
-  #  jsonpath='{.items[*].metadata.labels.kustomize\.toolkit\.fluxcd\.io/name}'
-  #  should read cluster-api-clusterclasses for all 4).
-  prune: false
+  prune: true
   # This Kustomization now holds ONLY the versioned templates
   # (OpenStackClusterTemplate / KubeadmControlPlaneTemplate / KubeadmConfigTemplate
   # / OpenStackMachineTemplate) — the ClusterClasses moved to


### PR DESCRIPTION
## What
Restore `prune: true` on the `cluster-api-templates` Kustomization now that adoption is confirmed.

## Why
The previous commit set `prune: false` as a temporary migration guard so the ClusterClasses wouldn't be deleted when they left the templates inventory. Adoption is now confirmed — all 4 ClusterClasses show `owner=cluster-api-clusterclasses` — so `prune: true` can be restored so old `-vN` templates can be garbage-collected again.

## Verification
```
kubectl get clusterclass -n mgmt -o jsonpath='{range .items[*]}{.metadata.name}={.metadata.labels.kustomize\.toolkit\.fluxcd\.io/name}{"\n"}{end}'
# openstack-default=cluster-api-clusterclasses
# openstack-default-v1=cluster-api-clusterclasses
# openstack-kamaji=cluster-api-clusterclasses
# openstack-kamaji-v1=cluster-api-clusterclasses
```