### PR TITLE
fix: fit mgmt workloads on 2 workers

### DIFF
--- a/clusters/mgmt/apps/chihiro/dragonfly.yaml
+++ b/clusters/mgmt/apps/chihiro/dragonfly.yaml
@@ -6,7 +6,10 @@ spec:
   replicas: 1
   resources:
     requests:
-      cpu: 500m
+      # Measured P95 ~8m / peak ~9m CPU over 3d (Mimir). 500m was a
+      # ~60x over-reservation that ate a worker's schedulable budget on
+      # a 2-node fleet; 100m keeps generous headroom.
+      cpu: 100m
       memory: 500Mi
     limits:
       cpu: 600m

--- a/infrastructure/kamaji/values.yaml
+++ b/infrastructure/kamaji/values.yaml
@@ -8,7 +8,9 @@ image:
 replicaCount: 3
 resources:
   requests:
-    cpu: 200m
+    # Measured P95 ~115m / peak ~124m CPU over 3d (Mimir). Trimmed from
+    # 200m to reclaim worker CPU budget; limit kept at 1 core.
+    cpu: 150m
     memory: 256Mi
   limits:
     cpu: "1"
@@ -17,27 +19,32 @@ kamaji-etcd:
   clusterDomain: "mgmt.local"
   resources:
     requests:
-      cpu: 500m
+      # Measured P95 ~115m / peak ~124m CPU per member over 3d (Mimir).
+      # 500m was ~4x peak and blocked scheduling on a 2-node fleet;
+      # 250m is 2x peak with headroom.
+      cpu: 250m
       memory: 256Mi
   # Spread the 3 etcd members across distinct nodes. Without this, node
   # churn (CAPI remediation) packed 2/3 members onto ONE worker (observed
-  # 2026-07-07), so a single node degraded EVERY tenant control plane —
-  # tenant apiservers timed out on liveness/readiness for hours and workload
-  # clusters' leader-elected controllers (e.g. csi-nfs-controller sidecars)
-  # crash-looped on lease-renewal timeouts. `required` (not preferred) on
-  # hostname, same convention as the Vault and rook MDS anti-affinity — with
-  # 3 mgmt workers a temporarily Pending member (quorum 2/3 intact) is
-  # preferable to co-location.
+  # 2026-07-07), so a single node degraded EVERY tenant control plane.
+  #
+  # PREFERRED (not required): the mgmt fleet is currently 2 workers, and
+  # `required` left the 3rd member Pending forever. `preferred` lets all 3
+  # members fit on 2 nodes (two may co-locate). TRADEOFF: losing the node
+  # that hosts 2 members drops etcd below quorum (2/3) until reschedule —
+  # accepted for a 2-node fleet. Restore `required` when a 3rd worker exists.
   affinity:
     podAntiAffinity:
-      requiredDuringSchedulingIgnoredDuringExecution:
-        - labelSelector:
-            matchExpressions:
-              - key: app.kubernetes.io/name
-                operator: In
-                values:
-                  - kamaji-etcd
-          topologyKey: "kubernetes.io/hostname"
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          podAffinityTerm:
+            labelSelector:
+              matchExpressions:
+                - key: app.kubernetes.io/name
+                  operator: In
+                  values:
+                    - kamaji-etcd
+            topologyKey: "kubernetes.io/hostname"
 gatewayAPI:
   enabled: false
 datastore:

--- a/infrastructure/vault/helmrelease.yaml
+++ b/infrastructure/vault/helmrelease.yaml
@@ -33,10 +33,24 @@ spec:
       # failover internally. The chart provisions a StatefulSet plus the
       # leader-aware `vault-active` / `vault-standby` services.
       #
-      # NOTE: the chart's server podAntiAffinity is
-      # requiredDuringSchedulingIgnoredDuringExecution on hostname, so the 3
-      # replicas REQUIRE 3 distinct schedulable nodes — otherwise the extra pods
-      # stay Pending. Reduce replicas (and quorum) if mgmt has fewer nodes.
+      # NOTE: the chart's DEFAULT server podAntiAffinity is
+      # requiredDuringSchedulingIgnoredDuringExecution on hostname, which REQUIRES
+      # 3 distinct schedulable nodes. On a 2-worker mgmt fleet the 3rd replica
+      # stays Pending forever. We override it to PREFERRED so all 3 replicas fit
+      # on 2 nodes (two members may co-locate). TRADEOFF: losing the node that
+      # hosts 2 members drops Raft below quorum (2/3) until reschedule — acceptable
+      # for a 2-node fleet; restore `required` (or a 3rd worker) for full HA.
+      affinity: |
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/name: {{ template "vault.name" . }}
+                    app.kubernetes.io/instance: "{{ .Release.Name }}"
+                    component: server
+                topologyKey: kubernetes.io/hostname
       ha:
         enabled: true
         replicas: 3


### PR DESCRIPTION
The mgmt fleet dropped to 2 workers, leaving pods Pending for two reasons:

**1. CPU-request over-reservation** (both workers pinned ~100% requests). Trimmed to measured usage (Mimir, 3d):
- `chihiro-dragonfly` 500m → 100m (P95 ~8m / peak ~9m)
- kamaji controller 200m → 150m (P95 ~115m)
- kamaji-etcd 500m → 250m per member (P95 ~115m / peak ~124m)

**2. Required hostname anti-affinity** on Vault (3 replicas) and kamaji-etcd (3 replicas) meant the 3rd replica could never schedule on 2 nodes (`vault-1`, `kamaji-etcd-0` Pending). Switched both from `requiredDuringScheduling` → `preferredDuringScheduling` so all replicas fit (two may co-locate).

**Tradeoff:** losing a node hosting 2 members of a quorum drops it to 2/3 until reschedule. Restore `required` (or add a 3rd worker) for full HA.

Verified `server.affinity` exists in vault chart 0.34.0 and `kamaji-etcd.affinity` flows through the live chart (dep `kamaji-etcd >=0.15.0`); kustomize build + treefmt/prettier pass.