### PR TITLE
fix: reclaim mgmt worker CPU from low-value platform pods

### DIFF
--- a/infrastructure/crossplane/values.yaml
+++ b/infrastructure/crossplane/values.yaml
@@ -1,3 +1,15 @@
 args:
   - --enable-usages
   - --enable-realtime-compositions
+# Right-sized CPU requests to reclaim worker budget on the 2-worker mgmt
+# fleet (chart defaults were 100m each). Measured (Mimir, 3d): core P95
+# ~72m/peak ~123m; rbac-manager P95 ~1m/peak ~2m. CPU request-only (no CPU
+# limit); memory left at chart defaults.
+resourcesCrossplane:
+  requests:
+    cpu: 60m
+    memory: 256Mi
+resourcesRBACManager:
+  requests:
+    cpu: 20m
+    memory: 256Mi

--- a/infrastructure/fluxcd/instances/flux.yaml
+++ b/infrastructure/fluxcd/instances/flux.yaml
@@ -74,6 +74,24 @@ spec:
           - op: replace
             path: /spec/template/spec/containers/0/resources/limits/memory
             value: 1536Mi
+      # Right-sized CPU requests (chart defaults were 100m each). Measured
+      # (Mimir, 3d, mgmt): notification P95 ~2m/peak ~2m; helm P95 ~19m/peak
+      # ~47m. kustomize (peak ~141m) and source keep their defaults. CPU
+      # request-only — bursts allowed above; no CPU limit added.
+      - target:
+          kind: Deployment
+          name: notification-controller
+        patch: |
+          - op: replace
+            path: /spec/template/spec/containers/0/resources/requests/cpu
+            value: 20m
+      - target:
+          kind: Deployment
+          name: helm-controller
+        patch: |
+          - op: replace
+            path: /spec/template/spec/containers/0/resources/requests/cpu
+            value: 60m
   sync:
     kind: GitRepository
     url: "https://github.com/RPCU/argus.git"

--- a/infrastructure/fluxcd/operator/helmrelease.yaml
+++ b/infrastructure/fluxcd/operator/helmrelease.yaml
@@ -16,3 +16,11 @@ spec:
     crds: CreateReplace
   upgrade:
     crds: CreateReplace
+  values:
+    # Right-sized CPU request to reclaim worker budget on the 2-worker mgmt
+    # fleet (chart default 100m). Measured P95 ~11m / peak ~45m (Mimir, 3d).
+    # CPU request-only; memory left at chart default.
+    resources:
+      requests:
+        cpu: 30m
+        memory: 64Mi


### PR DESCRIPTION
Frees ~310m of worker CPU requests on the 2-worker mgmt fleet so the Pending HA members (kamaji-etcd-0, vault-1) and the production tenant CP fit — **without trimming the tenant control plane** (it needs its headroom; per request we reduce from the rest instead).

All values are chart defaults trimmed to measured usage (Mimir, 3d), CPU request-only (no CPU limit):

| Pod | Was | Now | P95 / peak |
|---|---|---|---|
| crossplane core | 100m | 60m | 72m / 123m |
| crossplane rbac-manager | 100m | 20m | 1m / 2m |
| flux-operator | 100m | 30m | 11m / 45m |
| flux notification-controller | 100m | 20m | 2m / 2m |
| flux helm-controller | 100m | 60m | 19m / 47m |

flux kustomize-controller (peak ~141m) and source-controller keep defaults.

Verified value keys exist: crossplane 2.2.0 `resourcesCrossplane`/`resourcesRBACManager`; flux-operator 0.57.0 `resources`. Note `flux.yaml` + `flux-operator/helmrelease.yaml` are shared bases (reach all clusters) — values chosen conservative fleet-wide. kustomize build + treefmt pass.