### PR TITLE
fix: free more mgmt worker CPU for etcd + tenant control planes

### DIFF
--- a/infrastructure/grafana-operator/helmrelease.yaml
+++ b/infrastructure/grafana-operator/helmrelease.yaml
@@ -20,7 +20,9 @@ spec:
     watchNamespaces: ""
     resources:
       requests:
-        cpu: 100m
+        # Measured P95 ~2m / peak ~2m CPU over 3d (Mimir) — idle reconciler.
+        # Trimmed 100m -> 20m to free worker budget for etcd + tenant CPs.
+        cpu: 20m
         memory: 128Mi
       limits:
         memory: 512Mi

--- a/infrastructure/grafana/grafana.yaml
+++ b/infrastructure/grafana/grafana.yaml
@@ -70,7 +70,10 @@ spec:
                       optional: true
               resources:
                 requests:
-                  cpu: 250m
+                  # Measured P95 ~18m / peak ~19m CPU over 3d (Mimir). Trimmed
+                  # 250m -> 60m to free worker budget for etcd + tenant CPs;
+                  # 1000m limit retained for dashboard-render bursts.
+                  cpu: 60m
                   memory: 512Mi
                 limits:
                   cpu: 1000m

--- a/infrastructure/kamaji/values.yaml
+++ b/infrastructure/kamaji/values.yaml
@@ -8,9 +8,11 @@ image:
 replicaCount: 3
 resources:
   requests:
-    # Measured P95 ~115m / peak ~124m CPU over 3d (Mimir). Trimmed from
-    # 200m to reclaim worker CPU budget; limit kept at 1 core.
-    cpu: 150m
+    # Kamaji CONTROLLER manager (not etcd). Per-pod measured 0-2m CPU over 3d
+    # (Mimir); it's a low-churn reconciler. Trimmed 200m -> 50m (x3 replicas)
+    # to hand CPU budget to etcd + the tenant control planes, which matter more
+    # on the 2-worker mgmt fleet. Limit kept at 1 core for burst headroom.
+    cpu: 50m
     memory: 256Mi
   limits:
     cpu: "1"


### PR DESCRIPTION
Follow-up to #599/#600. Gives kamaji-etcd and the Kamaji tenant control planes more scheduling headroom on the 2-worker mgmt fleet by trimming idle, non-critical pods to measured usage (Mimir, 3d). CPU request-only.

| Pod | Was | Now | P95/peak |
|---|---|---|---|
| kamaji controller (x3) | 150m | 50m | 0-2m |
| grafana | 250m | 60m | 18m/19m |
| grafana-operator | 100m | 20m | 2m/2m |

Frees ~570m. **Deliberately left untouched** (per instruction to protect the important workloads): production tenant CP requests, prometheus (peak 165m), mimir-distributor (peak 414m), mimir-ingester (peak 193m), and sveltos-agent/drift-detection (not chart-tunable).

kustomize build + treefmt pass.