### PR TITLE
fix: correct grafana + crossplane CPU requests to real 7d usage

### DIFF
--- a/infrastructure/crossplane/values.yaml
+++ b/infrastructure/crossplane/values.yaml
@@ -2,12 +2,13 @@ args:
   - --enable-usages
   - --enable-realtime-compositions
 # Right-sized CPU requests to reclaim worker budget on the 2-worker mgmt
-# fleet (chart defaults were 100m each). Measured (Mimir, 3d): core P95
-# ~72m/peak ~123m; rbac-manager P95 ~1m/peak ~2m. CPU request-only (no CPU
-# limit); memory left at chart defaults.
+# fleet (chart defaults were 100m each). Measured over 7d (Mimir): core
+# avg ~15m / P95 ~72m / max ~123m; rbac-manager P95 ~2m / max ~3m. Core
+# request set to 80m (above P95) so it isn't starved; rbac to 20m. CPU
+# request-only (no CPU limit); memory left at chart defaults.
 resourcesCrossplane:
   requests:
-    cpu: 60m
+    cpu: 80m
     memory: 256Mi
 resourcesRBACManager:
   requests:

--- a/infrastructure/grafana/grafana.yaml
+++ b/infrastructure/grafana/grafana.yaml
@@ -70,10 +70,11 @@ spec:
                       optional: true
               resources:
                 requests:
-                  # Measured P95 ~18m / peak ~19m CPU over 3d (Mimir). Trimmed
-                  # 250m -> 60m to free worker budget for etcd + tenant CPs;
-                  # 1000m limit retained for dashboard-render bursts.
-                  cpu: 60m
+                  # Measured over 7d (Mimir): avg ~29m, P95 ~104m, max ~187m —
+                  # dashboard rendering is genuinely bursty. Request set to 120m
+                  # (just above P95) so it's not CPU-starved under contention;
+                  # trimmed from the original 250m. 1000m limit kept for bursts.
+                  cpu: 120m
                   memory: 512Mi
                 limits:
                   cpu: 1000m


### PR DESCRIPTION
Verified all merged CPU-request reductions against **7-day** Mimir history (the earlier 3-day per-pod query undercounted bursty pods). Two were below P95 and could be CPU-starved under contention — raised above P95:

| Pod | Was | Now | 7d P95 | 7d max |
|---|---|---|---|---|
| grafana | 60m | 120m | 104m | 187m |
| crossplane-core | 60m | 80m | 72m | 123m |

All other reductions confirmed safe (request ≥ P95):

| Pod | req | P95 | max |
|---|---|---|---|
| dragonfly | 100m | 8m | 9m |
| kamaji-etcd | 250m | 115m | 124m |
| kamaji-ctrl | 50m | 17m | 25m |
| crossplane-rbac | 20m | 2m | 3m |
| flux-operator | 30m | 12m | 45m |
| flux-notif | 20m | 2m | 4m |
| flux-helm | 60m | 19m | 47m |
| grafana-operator | 20m | 5m | 12m |

Requests only; no CPU limits changed. kustomize build + treefmt pass.