### PR TITLE
fix: grafana deployment strategy Recreate to avoid RWO PVC deadlock

### DIFF
--- a/infrastructure/grafana/grafana.yaml
+++ b/infrastructure/grafana/grafana.yaml
@@ -31,6 +31,12 @@ spec:
   # Deployment specification & env vars for Zitadel OIDC secret
   deployment:
     spec:
+      # Recreate avoids Multi-Attach errors on every rollout: the PVC is RWO,
+      # so RollingUpdate tries to attach the volume to the new pod before the
+      # old pod releases it. Recreate kills the old pod first, then creates the
+      # new one with a clean volume attach.
+      strategy:
+        type: Recreate
       template:
         spec:
           securityContext:


### PR DESCRIPTION
RollingUpdate causes Multi-Attach errors on every grafana rollout because the PVC is RWO — the new pod can't attach the volume until the old pod releases it, but the old pod won't terminate until the new pod is Ready. Recreate kills the old pod first, then creates the new one cleanly.

No functional change to grafana itself (dashboards/datasources are declarative CRs; only the sqlite DB is affected and it survives restarts).