### PR TITLE
fix: Opaque type for kamaji-apiserver-proxy-tls Secret

### DIFF
--- a/infrastructure/sveltos/clusterprofiles/kamaji-apiserver-proxy-certs.yaml
+++ b/infrastructure/sveltos/clusterprofiles/kamaji-apiserver-proxy-certs.yaml
@@ -157,7 +157,7 @@ data:
     metadata:
       name: kamaji-apiserver-proxy-tls
       namespace: kamaji-apiserver-proxy
-    type: kubernetes.io/tls
+    type: Opaque
     data:
       cert.pem: {{ index .Resource.data "apiserver.crt" }}
       key.pem: {{ index .Resource.data "apiserver.key" }}


### PR DESCRIPTION
kubernetes.io/tls requires tls.crt/tls.key keys, but Caddy uses cert.pem/key.pem filenames. Change to Opaque to allow arbitrary key names.