### PR TITLE
fix(kamaji-external): make in-cluster API server proxy work reliably

### DIFF
--- a/infrastructure/cluster-api-templates/templates/controlplane-kamaji-external.yaml
+++ b/infrastructure/cluster-api-templates/templates/controlplane-kamaji-external.yaml
@@ -41,7 +41,22 @@ spec:
           kubeconfigSecretName: placeholder
           kubeconfigSecretKey: value
       apiServer:
-        extraArgs: []
+        extraArgs:
+          # Stop the apiserver from reconciling the kubernetes.default Service
+          # endpoint. On an external Kamaji control plane the apiserver advertises
+          # its own (in-tenant, unreachable-from-workers) address 10.x.x.x:6443 as
+          # the kubernetes.default endpoint. That endpoint is useless — workers
+          # reach the API server through the node-local Caddy proxy + Cilium LRP
+          # (see infrastructure/sveltos/clusterprofiles/kamaji-apiserver-proxy.yaml)
+          # — AND it actively breaks that proxy: Cilium syncs the apiserver-managed
+          # ClusterIP Service entry (10.x.x.x:6443 backend) before/independently of
+          # the LRP, and on any node that joins AFTER the LRP is created the agent
+          # keeps the ClusterIP backend instead of converting it to LocalRedirect,
+          # so kubernetes.default:443 blackholes there. With reconciler-type=none
+          # the Service carries no apiserver endpoint, leaving the LRP as the sole
+          # owner of the ClusterIP on every node (including late joiners).
+          # The ClusterClass oidc patch appends the --oidc-* flags after this.
+          - --endpoint-reconciler-type=none
         resources:
           requests:
             cpu: 200m

--- a/infrastructure/sveltos/clusterprofiles/kamaji-apiserver-proxy.yaml
+++ b/infrastructure/sveltos/clusterprofiles/kamaji-apiserver-proxy.yaml
@@ -115,6 +115,15 @@ data:
             app.kubernetes.io/name: kamaji-apiserver-proxy
         spec:
           priorityClassName: system-node-critical
+          # Use the NODE's resolv.conf, NOT cluster CoreDNS. Caddy's upstream is
+          # the DNS name {{ .Cluster.spec.controlPlaneEndpoint.host }}, which must
+          # be resolvable to bootstrap the cluster. But CoreDNS itself depends on
+          # this proxy to reach the API server (kubernetes.default), so resolving
+          # the upstream via CoreDNS would deadlock: CoreDNS NotReady -> proxy 502
+          # -> API server unreachable -> CoreDNS stays NotReady. dnsPolicy: Default
+          # inherits the node resolver (populated by ExternalDNS/Designate), which
+          # resolves the control-plane FQDN without any in-cluster dependency.
+          dnsPolicy: Default
           # Tolerate all taints: this proxy is what makes the API server
           # reachable in-cluster, so it must schedule on nodes that are still
           # NotReady during bootstrap.
@@ -156,6 +165,13 @@ data:
                 capabilities:
                   drop:
                     - ALL
+                  # The caddy binary carries the file capability
+                  # cap_net_bind_service=ep. Dropping ALL without re-adding it
+                  # makes the kernel refuse to exec the binary (file-permitted
+                  # caps not in the bounding set) → "exec /usr/bin/caddy:
+                  # operation not permitted" → exit 255 CrashLoopBackOff.
+                  add:
+                    - NET_BIND_SERVICE
           volumes:
             - name: caddyfile
               configMap:
@@ -173,13 +189,27 @@ data:
             - name: data
               emptyDir: {}
   local-redirect-policy.yaml: |
-    # Redirect in-cluster kubernetes.default.svc traffic to the node-local Caddy
-    # proxy. Traffic flows: pod -> kubernetes.default.svc:443 -> (eBPF LRP) ->
+    # Redirect in-cluster API server traffic to the node-local Caddy proxy.
+    # Traffic flows: pod -> kubernetes.default ClusterIP:443 -> (eBPF LRP) ->
     # local Caddy:6443 -> (TLS termination + reverse_proxy) -> Gateway:6443 ->
     # TLSRoute -> TCP's kube-apiserver.
     #
+    # MUST use addressMatcher, NOT serviceMatcher. Cilium silently refuses to
+    # program an LRP whose serviceMatcher targets the special kubernetes.default
+    # service (the apiserver-managed ClusterIP): `cilium-dbg lrp list` shows the
+    # policy but no matching service, and the ClusterIP keeps routing to the
+    # unreachable Kamaji endpoint. addressMatcher on the raw ClusterIP works.
+    #
+    # The kubernetes.default ClusterIP is ALWAYS the first host of the service
+    # CIDR (network address + 1), so we derive it from the Cluster's
+    # clusterNetwork.services.cidrBlocks[0] instead of hardcoding it — this stays
+    # correct for any tenant cluster regardless of its service CIDR.
+    #
     # NOTE: LRP updates are not supported by Cilium (delete+recreate). Sveltos
     # drift correction recreates it, which is fine.
+    {{- $svcCidr := (index .Cluster.spec.clusterNetwork.services.cidrBlocks 0) }}
+    {{- $octets := splitList "." (first (splitList "/" $svcCidr)) }}
+    {{- $apiServerIP := printf "%s.%s.%s.1" (index $octets 0) (index $octets 1) (index $octets 2) }}
     apiVersion: cilium.io/v2
     kind: CiliumLocalRedirectPolicy
     metadata:
@@ -187,9 +217,11 @@ data:
       namespace: kamaji-apiserver-proxy
     spec:
       redirectFrontend:
-        serviceMatcher:
-          serviceName: kubernetes
-          namespace: default
+        addressMatcher:
+          ip: "{{ $apiServerIP }}"
+          toPorts:
+            - port: "443"
+              protocol: TCP
       redirectBackend:
         localEndpointSelector:
           matchLabels:


### PR DESCRIPTION
## Summary
Fixes the `openstack-kamaji-external` tenant API server proxy so pods can reach `kubernetes.default` in-cluster when the control plane runs on an external cluster. Debugged live on the `test` tenant cluster.

## Root causes fixed
1. **Caddy CrashLoopBackOff (exit 255)** — the `caddy` binary has the file capability `cap_net_bind_service=ep`. `capabilities.drop: [ALL]` without re-adding it makes the kernel refuse to exec the binary. Fix: `capabilities.add: [NET_BIND_SERVICE]`.
2. **CoreDNS deadlock** — Caddy's upstream is the tenant control-plane FQDN, but resolving it via cluster CoreDNS deadlocks (CoreDNS needs the API server, which needs this proxy). Fix: `dnsPolicy: Default` (node resolver, populated by ExternalDNS/Designate).
3. **LRP silently not programmed** — Cilium refuses to program a `serviceMatcher` LRP against the special `kubernetes.default` service. Fix: `addressMatcher` on the ClusterIP, derived dynamically from `clusterNetwork.services.cidrBlocks[0]` (first host), no hardcoding.
4. **Late-joining nodes blackhole** — the external apiserver publishes its unreachable in-tenant address as the `kubernetes.default` endpoint; Cilium keeps that ClusterIP backend on nodes that join after the LRP. Fix: `--endpoint-reconciler-type=none` on the external control plane so the Service carries no apiserver endpoint, leaving the LRP as sole owner on every node.

## Verified live
- Caddy pod `1/1 Running`; `cilium-dbg service list` shows `10.107.0.1:443 LocalRedirect => caddy:6443`.
- `curl https://10.107.0.1:443/healthz` -> `200`; CoreDNS became Ready; DNS resolves.

## Testing
- `kustomize build` passes for both `cluster-api-templates` and `sveltos/clusterprofiles`.
- LRP ClusterIP template renders `10.107.0.0/16` -> `10.107.0.1`.
- treefmt clean.