### PR TITLE
fix: lrp-reconcile CronJob — per-node check + RBAC fix

### DIFF
--- a/infrastructure/sveltos/clusterprofiles/kamaji-apiserver-proxy.yaml
+++ b/infrastructure/sveltos/clusterprofiles/kamaji-apiserver-proxy.yaml
@@ -265,6 +265,9 @@ data:
     metadata:
       name: kamaji-apiserver-lrp-reconcile
     rules:
+      - apiGroups: ["apps"]
+        resources: ["daemonsets"]
+        verbs: ["get"]
       - apiGroups: [""]
         resources: ["services"]
         verbs: ["get"]


### PR DESCRIPTION
Adds missing daemonsets RBAC verb, checks LRP on every node via exec into Cilium pods, and only restarts agents on nodes where LRP is not programmed.