### PR TITLE
feat: dike sveltos add-on for kamaji-apiserver-proxy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -407,6 +407,18 @@ Dragonfly` CRD) via a Flux takeover of the SAME base mgmt uses,
     Kustomizations; `gateway-api-resources` (`dependsOn: gateway-api`) pushes the
     Gateway (`*.cluster.rpcu.lan`, `vault-issuer`), GatewayParameters, wildcard
     Certificate, HTTPRoute, HTTPListenerPolicy. Split so CRs land AFTER CRDs.
+  - `dike.yaml` (`dependsOn: cilium`, label `.../kamaji-apiserver-proxy`) —
+    companion controller (RPCU/dike, a kubebuilder operator) for the
+    kamaji-apiserver-proxy. Inline ConfigMap (NOT a Flux takeover — same pattern
+    as `kamaji-apiserver-proxy.yaml`; self-contained ns/SA/RBAC/Deployment, only
+    needs the Cilium CRDs) carrying dike's upstream `deploy.yaml`
+    (`zot.rpcu.io/public/dike`, public repo → no imagePullSecret; RBAC:
+    ciliumlocalredirectpolicies get/list/watch/update/patch + pods
+    get/list/watch/delete + pods/exec — it reconciles the LRP + Caddy pods the
+    proxy creates, working around Cilium's no-LRP-update limitation). Gated by the
+    SAME opt-in label as the proxy it complements, so a tenant cluster that gets
+    the proxy gets its controller too. Image pinned `v0.1.0` (Renovate marker
+    `# renovate: datasource=docker depName=zot.rpcu.io/public/dike`).
 
 - **cluster-api-operator/** (v0.27.0, ns capi-operator-system) — chart-managed
   cert-manager disabled; providers managed separately.
@@ -710,7 +722,7 @@ github-releases (external-snapshotter); (3) Crossplane packages → docker;
 (4) CAPI provider `version:` via inline `# renovate:` markers; (5) Sveltos inline
 `helmCharts chartVersion:`; (6) helm-values `tag:` without sibling repository
 (kamaji); (7) plain `image:` → docker (rook ceph pinned `v19.2.3`, grouped;
-chihiro).
+chihiro; the dike Sveltos add-on `zot.rpcu.io/public/dike`).
 
 **NOT Renovate-managed:** npins (`.github/workflows/npins-update.yaml`, 6h) and
 yaook OpenStack releases (`.github/workflows/yaook-releases.yaml`, weekly —
@@ -1004,8 +1016,22 @@ env; pre-commit quality gates; 1-minute Git sync.
 
 ---
 
-**Last Updated**: August 2026 — **Fixed three dead top-level keys in
-`infrastructure/kamaji/values.yaml`** (`etcd:`, `datastore:`, `gatewayAPI:`).
+**Last Updated**: August 2026 — **Added the `dike` Sveltos add-on**
+(`infrastructure/sveltos/clusterprofiles/dike.yaml`, registered in that dir's
+`kustomization.yaml`): a companion controller (RPCU/dike) for the
+kamaji-apiserver-proxy, gated by the SAME opt-in label
+(`sveltos.argus.rpcu.io/kamaji-apiserver-proxy: enabled`) so any tenant cluster
+that gets the proxy gets its controller too. Delivered as an inline ConfigMap
+(NOT a Flux takeover — same pattern as `kamaji-apiserver-proxy.yaml`; dike is
+self-contained ns/SA/RBAC/Deployment and only needs the Cilium CRDs, so
+`dependsOn: cilium`). RBAC mirrors dike's upstream `deploy.yaml`
+(ciliumlocalredirectpolicies get/list/watch/update/patch + pods
+get/list/watch/delete + pods/exec — it reconciles the LRP + Caddy pods the proxy
+creates, working around Cilium's no-LRP-update limitation). Image
+`zot.rpcu.io/public/dike` pinned `v0.1.0` with a Renovate `datasource=docker`
+marker (tracked under the plain-`image:` regex manager). — Prior: **Fixed three
+dead top-level keys in `infrastructure/kamaji/values.yaml`** (`etcd:`,
+`datastore:`, `gatewayAPI:`).
 None of them are kamaji chart keys — verified against the chart embedded in the
 live Helm release secret, `clastix/kamaji@master` + `clastix/kamaji-etcd@master`
 on GitHub, and a `.Values.*` template grep (0 references each). They rendered

--- a/infrastructure/sveltos/clusterprofiles/dike.yaml
+++ b/infrastructure/sveltos/clusterprofiles/dike.yaml
@@ -1,0 +1,156 @@
+# dike — companion controller for the kamaji-apiserver-proxy.
+#
+# PROBLEM. The kamaji-apiserver-proxy (see kamaji-apiserver-proxy.yaml) redirects
+# in-cluster API server traffic (kubernetes.default) to a node-local Caddy pod via
+# a CiliumLocalRedirectPolicy. Cilium does NOT support updating an LRP (it must be
+# delete+recreate), and the Caddy pods that back it need to be reconciled/cleaned
+# up as nodes and certs churn. dike is the small kubebuilder operator that manages
+# those ciliumlocalredirectpolicies + backing pods (RBAC below mirrors dike's
+# deploy.yaml: ciliumlocalredirectpolicies get/list/watch/update/patch, pods
+# get/list/watch/delete + pods/exec).
+#
+# DELIVERY. Inline ConfigMap (same pattern as kamaji-apiserver-proxy.yaml), NOT a
+# Flux takeover: dike is self-contained (ns/SA/RBAC/Deployment) and only needs the
+# Cilium CRDs, so there is no reason to route it through Flux. The manifests below
+# are the upstream RPCU/dike deploy.yaml (image zot.rpcu.io/public/dike, public
+# repo → no imagePullSecret).
+#
+# Gated by the SAME opt-in label as the proxy it complements —
+# sveltos.argus.rpcu.io/kamaji-apiserver-proxy: enabled — so a tenant cluster that
+# gets the proxy gets its controller too.
+#
+# dependsOn cilium: the ciliumlocalredirectpolicies CRD must exist.
+apiVersion: config.projectsveltos.io/v1beta1
+kind: ClusterProfile
+metadata:
+  name: dike
+  namespace: projectsveltos
+spec:
+  syncMode: ContinuousWithDriftDetection
+  dependsOn:
+    - cilium
+  clusterSelector:
+    matchLabels:
+      type: workload
+      sveltos.argus.rpcu.io/kamaji-apiserver-proxy: enabled
+      sveltos.argus.rpcu.io/cilium: enabled
+  policyRefs:
+    - name: dike-resources
+      namespace: projectsveltos
+      kind: ConfigMap
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: dike-resources
+  namespace: projectsveltos
+data:
+  namespace.yaml: |
+    apiVersion: v1
+    kind: Namespace
+    metadata:
+      name: dike-system
+      labels:
+        app.kubernetes.io/name: dike
+  serviceaccount.yaml: |
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      name: dike-controller-manager
+      namespace: dike-system
+  clusterrole.yaml: |
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      name: dike-manager-role
+    rules:
+      - apiGroups: ["cilium.io"]
+        resources: ["ciliumlocalredirectpolicies"]
+        verbs: ["get", "list", "watch", "update", "patch"]
+      - apiGroups: [""]
+        resources: ["pods"]
+        verbs: ["get", "list", "watch", "delete"]
+      - apiGroups: [""]
+        resources: ["pods/exec"]
+        verbs: ["create", "get"]
+      - apiGroups: [""]
+        resources: ["nodes", "namespaces", "services"]
+        verbs: ["get", "list", "watch"]
+      - apiGroups: ["coordination.k8s.io"]
+        resources: ["leases"]
+        verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+      - apiGroups: [""]
+        resources: ["events"]
+        verbs: ["create", "patch"]
+  clusterrolebinding.yaml: |
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      name: dike-manager-rolebinding
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: dike-manager-role
+    subjects:
+      - kind: ServiceAccount
+        name: dike-controller-manager
+        namespace: dike-system
+  deployment.yaml: |
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: dike-controller-manager
+      namespace: dike-system
+      labels:
+        app.kubernetes.io/name: dike
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          app.kubernetes.io/name: dike
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/name: dike
+        spec:
+          serviceAccountName: dike-controller-manager
+          securityContext:
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+          containers:
+            - name: manager
+              # renovate: datasource=docker depName=zot.rpcu.io/public/dike
+              image: zot.rpcu.io/public/dike:v0.1.0
+              imagePullPolicy: IfNotPresent
+              command:
+                - /manager
+              args:
+                - --leader-elect
+                - --health-probe-bind-address=:8081
+              securityContext:
+                readOnlyRootFilesystem: true
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - "ALL"
+              livenessProbe:
+                httpGet:
+                  path: /healthz
+                  port: 8081
+                initialDelaySeconds: 15
+                periodSeconds: 20
+              readinessProbe:
+                httpGet:
+                  path: /readyz
+                  port: 8081
+                initialDelaySeconds: 5
+                periodSeconds: 10
+              resources:
+                limits:
+                  cpu: 500m
+                  memory: 128Mi
+                requests:
+                  cpu: 10m
+                  memory: 64Mi
+          terminationGracePeriodSeconds: 10

--- a/infrastructure/sveltos/clusterprofiles/kustomization.yaml
+++ b/infrastructure/sveltos/clusterprofiles/kustomization.yaml
@@ -16,6 +16,7 @@ resources:
   - gateway-api.yaml
   - kamaji-apiserver-proxy.yaml
   - kamaji-apiserver-proxy-certs.yaml
+  - dike.yaml
   - monitoring.yaml
 # Stamp every resource in this directory (ClusterProfiles + their backing
 # ConfigMaps/Secrets/EventSources/EventTriggers) with a common metadata label.


### PR DESCRIPTION
## Summary

Adds the **dike** (RPCU/dike) companion controller as a Sveltos add-on, gated on the **same opt-in label** as the kamaji-apiserver-proxy (`sveltos.argus.rpcu.io/kamaji-apiserver-proxy: enabled`) — so any tenant cluster that gets the proxy gets its controller too.

## Details

- **New** `infrastructure/sveltos/clusterprofiles/dike.yaml` — `ClusterProfile/dike` (`syncMode: ContinuousWithDriftDetection`, `dependsOn: cilium`) + inline `dike-resources` ConfigMap carrying dike's upstream `deploy.yaml` (ns `dike-system`, SA, ClusterRole/Binding, single-replica Deployment).
- Delivered as an **inline ConfigMap** (NOT a Flux takeover) — same pattern as `kamaji-apiserver-proxy.yaml`; dike is self-contained and only needs the Cilium CRDs.
- RBAC mirrors dike's `deploy.yaml`: `ciliumlocalredirectpolicies` get/list/watch/update/patch + `pods` get/list/watch/delete + `pods/exec` — it reconciles the LRP + Caddy pods the proxy creates, working around Cilium's no-LRP-update limitation.
- Image `zot.rpcu.io/public/dike` pinned `v0.1.0` with a Renovate `datasource=docker` marker.
- Registered in `clusterprofiles/kustomization.yaml`; AGENTS.md §1 + Renovate note + Last Updated updated.

## Verification

- `kustomize build infrastructure/sveltos/clusterprofiles/` — OK
- `prettier --check` — OK
- `renovate-config-validator renovate.json5` — OK